### PR TITLE
2/8 Lose castling rights when a Rook is captured

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ Verified against the [reference results](https://www.chessprogramming.org/Perft_
 | Kiwipete | 3 | 97,862 | ✅ |
 | Position 3 | 2 | 191 | ❌ known bug — en passant discovered check |
 | Position 4 | 3 | 9,467 | ✅ |
-| Position 5 | 3 | 62,379 | ❌ known bug — castling with a captured rook |
+| Position 5 | 3 | 62,379 | ✅ |
 
-Both failures are over-counts: the generator emits a small number of illegal moves in these
-edge cases. See the open issues.
+The remaining failure is an over-count: the generator emits two illegal moves at depth 2,
+where an en passant capture vacates two squares on the same rank and exposes the king.
 
 ## Playing against other engines
 

--- a/game/board.py
+++ b/game/board.py
@@ -712,9 +712,10 @@ class Board:
         else:
             self.en_passant_sq = None
 
-        # Update castling rights if the king or rook move
-        if piece.type in (KING, ROOK):
-            self._update_castling_rights()
+        # Update castling rights. This must run for every move, not just King and Rook
+        # moves: capturing a Rook on its original square also removes castling rights, and
+        # the capturing piece can be of any type.
+        self._update_castling_rights()
 
         # Reset halfmove clock if a pawn moved or a piece was captured
         if piece.type == PAWN or captured_piece:

--- a/tests/test_moves.py
+++ b/tests/test_moves.py
@@ -111,6 +111,29 @@ class TestMoves(unittest.TestCase):
         self.assertEqual(bb.fen, '2kr1bnr/1bp1pppp/1pnq4/p2p4/7P/P2P1NP1/1PP1PPB1/RNBQ1RK1 w - - 3 8')
         self.assertEqual(bb.castle_flags, '-')
 
+    def test_castling_rights_lost_when_rook_captured(self):
+        """
+        A Rook captured on its original square takes its castling right with it, even though
+        the capturing piece is neither a King nor a Rook.
+        """
+        bb = Board('r3k2r/pppppppp/8/8/8/6n1/PPPPPPPP/R3K2R b KQkq - 0 1')
+        self.assertEqual(bb.castle_flags, 'KQkq')
+
+        bb.make_move(Move.from_uci('g3h1'))  # Black Knight takes the Rook on h1
+
+        piece = bb.piece_at(H1)
+        self.assertEqual((piece.type, piece.colour), (KNIGHT, BLACK))
+        self.assertEqual(bb.castle_flags, 'Qkq')
+
+        # White may still castle Queenside, but Kingside is gone with the Rook. Offering it
+        # would let White capture the Knight and conjure a Rook onto f1.
+        self.assertEqual({m.uci for m in bb.legal_moves if m.is_castling}, {'e1c1'})
+
+        # Undoing the capture restores the Rook and the right along with it
+        bb.unmake_move()
+        self.assertEqual(bb.castle_flags, 'KQkq')
+        self.assertEqual({m.uci for m in bb.legal_moves if m.is_castling}, {'e8g8', 'e8c8'})
+
     def test_en_passant(self):
         bb = Board()
         for m in (

--- a/tests/test_permutations.py
+++ b/tests/test_permutations.py
@@ -5,16 +5,35 @@ from game.board import *
 
 
 class TestPermutations(unittest.TestCase):
-    def test_perft(self):
-        # Verifying possible moves from starting state, as per https://www.chessprogramming.org/Perft_Results
-        b = Board(STARTING_STATE)
-        self.assertEqual(traverse_moves(b, 1, False), 20)
-        self.assertEqual(traverse_moves(b, 2, False), 400)
-        self.assertEqual(traverse_moves(b, 3, False), 8902)
+    """
+    Perft move enumeration, verified against the reference counts published at
+    https://www.chessprogramming.org/Perft_Results
+    """
 
-        # Following tests have been verified but are slow to test
-        # self.assertEqual(traverse_moves(b, 4, False), 197281)  # 5 seconds
-        # self.assertEqual(traverse_moves(b, 5, False), 4865609) # 2 minutes
+    def _assert_perft(self, fen: str, counts: dict):
+        for depth in sorted(counts):
+            board = Board(fen)
+            self.assertEqual(
+                traverse_moves(board, depth, False),
+                counts[depth],
+                f"perft({depth}) mismatch for {fen}",
+            )
+
+    def test_perft_starting_position(self):
+        self._assert_perft(STARTING_STATE, {1: 20, 2: 400, 3: 8902})
+
+        # Verified, but too slow for the suite: depth 4 = 197281, depth 5 = 4865609
+
+    def test_perft_position_5(self):
+        """
+        Black has a Knight on f2 bearing down on h1, so this position is only enumerated
+        correctly if capturing a Rook on its original square removes the matching castling
+        right. Otherwise White is offered a castle with a Rook that no longer exists.
+        """
+        self._assert_perft(
+            'rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8',
+            {1: 44, 2: 1486, 3: 62379},
+        )
 
 
 def main():


### PR DESCRIPTION
Second of eight sequential PRs from the correctness audit. Follows #33.

This is the bug that creates material out of nothing.

## The bug

`_update_castling_rights()` was only called when the piece **being moved** was a King or Rook:

```python
# Update castling rights if the king or rook move
if piece.type in (KING, ROOK):
    self._update_castling_rights()
```

It therefore never ran when a Rook was **captured** — the capturing piece can be anything. The rights bitboard kept a bit for a Rook that no longer existed.

`_pseudo_legal_moves` then happily offered the castle, because it only checks that the squares *between* King and Rook are empty, never that the Rook is still there. And `make_move` removed whatever sat on the corner square and placed a friendly Rook:

```
rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8
a2a3  f2h1     # Black Knight captures the h1 Rook
e1g1           # White "castles"
```

```
before ...Nxh1               after White "castles"
1 [♖][♘][♗][♕][♔][ ][ ][♞]   1 [♖][♘][♗][♕][ ][♖][♔][ ]
                                                ^^^
```

The Black Knight on h1 is deleted and a **white Rook materialises on f1**. White gains a Rook, Black loses a Knight, from nothing.

## The fix

Call `_update_castling_rights()` for every move. It already ANDs against `BB_ORIGINAL_ROOKS & self.rooks[colour] & self.castling_rights[colour]`, so it is idempotent and self-correcting, and it early-returns once both sides have lost all rights.

## Tests

Both new tests were confirmed to **fail without the fix** and pass with it:

- `test_perft_position_5` — Position 5 of the reference suite, chosen because Black's f2 Knight bears down on h1. Depth 3 was over-counting by 37 (`62,416` vs `62,379`).
- `test_castling_rights_lost_when_rook_captured` — asserts `castle_flags` drops the Kingside right, that no Kingside castle is offered, that Queenside is unaffected, and that `unmake_move` restores both the Rook and the right.

`tests/test_permutations.py` also gained a small `_assert_perft` helper and a per-position structure, so PRs 3 and 4 can drop their fixtures in without reshaping the file.

## Verification

```
$ python3 -m unittest tests.test_all -v
Ran 22 tests in 0.565s
OK
```

Perft scoreboard — Position 5 now green:

| Position | Depth | Expected | Status |
|---|---|---|---|
| Starting position | 4 | 197,281 | ✅ |
| Kiwipete | 3 | 97,862 | ✅ |
| Position 3 | 2 | 191 | ❌ en passant discovered check → PR 3 |
| Position 4 | 3 | 9,467 | ✅ |
| Position 5 | 3 | 62,379 | ✅ **fixed here** |

Speed guard — `_update_castling_rights()` now runs on every move, so this is the one change on the hot path worth measuring:

```
perft(4): 197,281 nodes in 1.64s = 120,547 nodes/s   (baseline ~110,000)
```

No regression; the early-return keeps it free once rights are gone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFTrYZkCWHVtFL6Lj3f7yD)_