### PR TITLE
3/8 Reject en passant captures that expose their own King

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,11 @@ Verified against the [reference results](https://www.chessprogramming.org/Perft_
 |---|---|---|---|
 | Starting position | 4 | 197,281 | ✅ |
 | Kiwipete | 3 | 97,862 | ✅ |
-| Position 3 | 2 | 191 | ❌ known bug — en passant discovered check |
+| Position 3 | 4 | 43,238 | ✅ |
 | Position 4 | 3 | 9,467 | ✅ |
 | Position 5 | 3 | 62,379 | ✅ |
 
-The remaining failure is an over-count: the generator emits two illegal moves at depth 2,
-where an en passant capture vacates two squares on the same rank and exposes the king.
+Move generation matches the reference counts on every position in the standard suite.
 
 ## Playing against other engines
 

--- a/game/board.py
+++ b/game/board.py
@@ -602,7 +602,26 @@ class Board:
                     if not _is_safe(attackers, king_pos, move):
                         continue
 
+            # En passant clears two squares on the same rank at once: the capturing pawn
+            # leaves, and the captured pawn is removed from beside it. The pin detection
+            # above cannot see this, because self._protectors only recognises a pin held by
+            # exactly one blocker. Play these captures out and look at the result instead.
+            if self._is_en_passant(move):
+                self.make_move(move)
+                exposed = self.kings[not self.turn] & self._attack_bitboard(self.turn)
+                self.unmake_move()
+                if exposed:
+                    continue
+
             yield move
+
+    def _is_en_passant(self, move: Move) -> bool:
+        """Whether the move captures en passant. Matches the condition used by make_move."""
+        return (
+            self.en_passant_sq is not None and
+            move.to_square == self.en_passant_sq and
+            bool(self.pawns[self.turn] & BB_SQUARES[move.from_square])
+        )
 
     @property
     def turn_name(self) -> str:

--- a/tests/test_moves.py
+++ b/tests/test_moves.py
@@ -149,6 +149,28 @@ class TestMoves(unittest.TestCase):
             bb.make_move(move)
         self.assertEqual(bb.fen, 'rnbqkbnr/pppppp1p/8/8/P7/5p2/1PPPP1PP/RNBQKBNR w KQkq - 0 4')
 
+    def test_en_passant_discovered_check(self):
+        """
+        En passant clears two squares on the same rank at once: the capturing pawn leaves,
+        and the captured pawn is removed from beside it. If the King sits on that rank the
+        capture can expose it, which makes the capture illegal.
+        """
+        # White Ka5 and Black Rh5 share rank 5, with the White b5 pawn and the Black c5 pawn
+        # between them. Taking c5 en passant would remove both and open the rank.
+        bb = Board('8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1')
+        bb.make_move(Move.from_uci('b4b3'))
+        bb.make_move(Move.from_uci('c7c5'))
+
+        self.assertEqual(bb.en_passant_sq, C6)
+        self.assertEqual({m.uci for m in bb.legal_moves if m.from_square == B5}, {'b5b6'})
+
+        # The same applies to Black, whose King on h4 shares rank 4 with the White b4 Rook
+        bb = Board('8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1')
+        bb.make_move(Move.from_uci('g2g4'))
+
+        self.assertEqual(bb.en_passant_sq, G3)
+        self.assertEqual({m.uci for m in bb.legal_moves if m.from_square == F4}, {'f4f3'})
+
     def test_promotion(self):
         b = Board('rnbqr3/pppp2P1/3k1n1p/2p1p3/3b4/8/PPPPPP1P/RNBQKBNR w KQ - 0 1')
         promotion_moves = set()

--- a/tests/test_permutations.py
+++ b/tests/test_permutations.py
@@ -24,6 +24,17 @@ class TestPermutations(unittest.TestCase):
 
         # Verified, but too slow for the suite: depth 4 = 197281, depth 5 = 4865609
 
+    def test_perft_position_3(self):
+        """
+        An endgame with pawns abreast of both Kings on open ranks, so this position is only
+        enumerated correctly if an en passant capture that exposes its own King is rejected.
+        Both colours have such a capture available here.
+        """
+        self._assert_perft(
+            '8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1',
+            {1: 14, 2: 191, 3: 2812, 4: 43238},
+        )
+
     def test_perft_position_5(self):
         """
         Black has a Knight on f2 bearing down on h1, so this position is only enumerated


### PR DESCRIPTION
Third of eight sequential PRs from the correctness audit. Follows #34.

**This is the last move generation defect — the full standard perft suite passes after this.**

## The bug

`legal_moves` detects pins via `_protectors`, which only recognises a pin held by **exactly one** blocker:

```python
_blocker = BB_BETWEEN[attacker_sq][target] & self.occupied
if _blocker and BB_SQUARES[msb(_blocker)] == _blocker:  # Check there's exactly one blocker
```

En passant is the one move in chess that clears **two** squares on the same rank at once — the capturing pawn leaves, and the captured pawn is removed from beside it. A King shielded by that pair is exposed by a capture the pin detection cannot model.

```
8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1
b4b3  c7c5  b5c6
```

```
before b5xc6 e.p.              after b5xc6 e.p.
5 [♔][♙][♟][ ][ ][ ][ ][♜]     5 [♔][ ][ ][ ][ ][ ][ ][♜]
   ^^^ King  ^^^^^^ shield        ^^^ King now on an open rank
```

Black replies `h5a5` and takes the King. The mirror case (`g2g4 f4g3`, `e2e4 f4e3`) exposes the *Black* King on h4 to the White Rook on b4.

## The fix

Play these captures out and look at the result, rather than trying to model them:

```python
if self._is_en_passant(move):
    self.make_move(move)
    exposed = self.kings[not self.turn] & self._attack_bitboard(self.turn)
    self.unmake_move()
    if exposed:
        continue
```

`_is_en_passant` is factored out so it mirrors the condition `make_move` already uses to decide the same thing — the two must not drift apart.

This reuses the existing `make_move`/`unmake_move` path rather than adding a second board-mutation route. It is safe inside the generator because the pair is balanced: the board is restored before the move is yielded.

## Cost

The branch is gated on `en_passant_sq is not None`, so it short-circuits on almost every move:

| Position | perft | Rate |
|---|---|---|
| Starting position (few e.p.) | 4 → 197,281 | **120,295 nodes/s** |
| Position 3 (e.p. heavy) | 4 → 43,238 | **141,478 nodes/s** |

Baseline before this PR was ~120,000 nodes/s. No measurable regression even on the position built to exercise this exact case.

## Tests

Confirmed to **fail without the fix** (`193 != 191`) and pass with it:

- `test_perft_position_3` — depths 1–4, the position chosen because both colours have an exposing en passant available
- `test_en_passant_discovered_check` — asserts the capture is absent for White *and* for Black, checking the `en_passant_sq` is genuinely set first so the test can't pass vacuously

The existing `test_en_passant` still passes, confirming legitimate en passant captures are unaffected.

## Verification

```
$ python3 -m unittest tests.test_all
Ran 24 tests in 0.920s
OK
```

**Full standard perft suite, all green:**

| Position | Depth | Expected | Status |
|---|---|---|---|
| Starting position | 4 | 197,281 | ✅ |
| Kiwipete | 3 | 97,862 | ✅ |
| Position 3 | 4 | 43,238 | ✅ **fixed here** |
| Position 4 | 3 | 9,467 | ✅ |
| Position 5 | 3 | 62,379 | ✅ |

Kiwipete and Position 4 aren't in the suite as committed tests yet — they land in PR 4, where parsing the FEN castling field makes them stronger tests than they would be today.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFTrYZkCWHVtFL6Lj3f7yD)_