### PR TITLE
4/8 Honour the castling field when loading a FEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Verified against the [reference results](https://www.chessprogramming.org/Perft_
 | Position 4 | 3 | 9,467 | ✅ |
 | Position 5 | 3 | 62,379 | ✅ |
 
-Move generation matches the reference counts on every position in the standard suite.
+All five run as part of the test suite (`tests/test_permutations.py`), so move generation is
+pinned to the reference counts rather than merely known to have matched them once.
 
 ## Playing against other engines
 

--- a/game/bitboard.py
+++ b/game/bitboard.py
@@ -179,6 +179,14 @@ BB_ORIGINAL_ROOKS = {
     WHITE: (BB_A1 | BB_H1),
     BLACK: (BB_A8 | BB_H8),
 }
+
+# Castling availability flags from FEN notation, mapped to the Rook each one refers to
+BB_CASTLING_FLAGS = {
+    'K': (WHITE, BB_H1),
+    'Q': (WHITE, BB_A1),
+    'k': (BLACK, BB_H8),
+    'q': (BLACK, BB_A8),
+}
 BB_KNIGHT_MOVES = _gen_moves(((1, 2), (1, -2), (-1, 2), (-1, -2), (2, 1), (2, -1), (-2, 1), (-2, -1)))
 BB_KING_MOVES = _gen_moves(((1, 1), (0, 1), (1, 0), (-1, -1), (-1, 0), (0, -1), (1, -1), (-1, 1)))
 BB_PAWN_ATTACKS = {

--- a/game/board.py
+++ b/game/board.py
@@ -154,6 +154,9 @@ class Board:
             assert turn in ['w', 'b'], "Invalid FEN."
             self.turn = BLACK if turn == 'b' else WHITE
 
+        if len(components) > 2:
+            self._set_castling_rights_from_fen(components[2])
+
         if len(components) > 3:
             _en_passant_coord = components[3].upper()
             self.en_passant_sq = None if _en_passant_coord == '-' else Square.from_coord(_en_passant_coord)
@@ -164,7 +167,26 @@ class Board:
         if len(components) > 5:
             self.fullmoves = int(components[5])
 
-        self._update_castling_rights()  # Cache castling rights
+        # Narrow whatever we ended up with to the Kings and Rooks actually on the board. When
+        # the FEN carried no castling field this is the only thing that sets the rights, and
+        # they are inferred from piece placement alone.
+        self._update_castling_rights()
+
+    def _set_castling_rights_from_fen(self, flags: str):
+        """
+        Sets castling rights from the availability field of a FEN string.
+
+        Rights are a property of the game's history rather than of the position, so they
+        cannot be recovered from piece placement: a King and Rook can stand on their original
+        squares having already moved away and back, which forfeits the right permanently.
+        """
+        rights = {WHITE: BB_EMPTY, BLACK: BB_EMPTY}
+        if flags != '-':
+            for flag in flags:
+                assert flag in BB_CASTLING_FLAGS, f'{flag} is not a valid castling right in FEN notation.'
+                colour, bb_rook = BB_CASTLING_FLAGS[flag]
+                rights[colour] |= bb_rook
+        self.castling_rights = rights
 
     def _attack_rays_from_square(
             self, square: Square, directions: Iterable[Direction], ignore: Bitboard = BB_EMPTY,

--- a/tests/test_moves.py
+++ b/tests/test_moves.py
@@ -111,6 +111,47 @@ class TestMoves(unittest.TestCase):
         self.assertEqual(bb.fen, '2kr1bnr/1bp1pppp/1pnq4/p2p4/7P/P2P1NP1/1PP1PPB1/RNBQ1RK1 w - - 3 8')
         self.assertEqual(bb.castle_flags, '-')
 
+    def test_fen_castling_field_round_trip(self):
+        """Every castling availability field survives a load and a re-render of the FEN."""
+        for flags in ('KQkq', 'KQk', 'KQ', 'Kkq', 'Kq', 'K', 'Qkq', 'Q', 'kq', 'k', 'q', '-'):
+            fen = f'r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w {flags} - 0 1'
+            _board = Board(fen=fen)
+            self.assertEqual(_board.castle_flags, flags)
+            self.assertEqual(_board.fen, fen)
+
+    def test_fen_castling_field_is_honoured(self):
+        """
+        Castling rights come from the FEN, not from where the pieces happen to stand. Every
+        King and Rook here is on its original square, but the FEN says the rights are gone.
+        """
+        _board = Board(fen='r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w - - 0 1')
+        self.assertEqual(_board.castle_flags, '-')
+        self.assertEqual({m.uci for m in _board.legal_moves if m.is_castling}, set())
+
+    def test_fen_castling_field_narrowed_to_the_board(self):
+        """A FEN claiming rights that the pieces cannot support is narrowed to reality."""
+        _board = Board(fen='4k3/8/8/8/8/8/8/4K3 w KQkq - 0 1')  # No Rooks anywhere
+        self.assertEqual(_board.castle_flags, '-')
+
+    def test_fen_without_castling_field_infers_from_position(self):
+        """Short FENs carry no castling field, so rights fall back to piece placement."""
+        self.assertEqual(Board(fen='rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w').castle_flags, 'KQkq')
+        self.assertEqual(Board(fen='4k3/8/8/8/8/8/8/4K3 w').castle_flags, '-')
+
+    def test_fen_does_not_resurrect_lost_castling_rights(self):
+        """
+        A round trip through FEN must not hand back rights the game has already forfeited.
+        ai.algorithms.alpha_beta rebuilds a Board from board.fen for every root move, so the
+        search would otherwise plan castles the real game can no longer play.
+        """
+        bb = Board('r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1')
+        for uci in ('e1e2', 'e8e7', 'e2e1', 'e7e8'):  # Both Kings step out and back
+            bb.make_move(Move.from_uci(uci))
+
+        self.assertEqual(bb.castle_flags, '-')
+        self.assertEqual(Board(bb.fen).castle_flags, '-')
+        self.assertEqual({m.uci for m in Board(bb.fen).legal_moves if m.is_castling}, set())
+
     def test_castling_rights_lost_when_rook_captured(self):
         """
         A Rook captured on its original square takes its castling right with it, even though

--- a/tests/test_permutations.py
+++ b/tests/test_permutations.py
@@ -20,9 +20,30 @@ class TestPermutations(unittest.TestCase):
             )
 
     def test_perft_starting_position(self):
-        self._assert_perft(STARTING_STATE, {1: 20, 2: 400, 3: 8902})
+        self._assert_perft(STARTING_STATE, {1: 20, 2: 400, 3: 8902, 4: 197281})
 
-        # Verified, but too slow for the suite: depth 4 = 197281, depth 5 = 4865609
+        # Verified, but too slow for the suite: depth 5 = 4865609
+
+    def test_perft_kiwipete(self):
+        """
+        The standard second position: castling available to both colours on both sides, with
+        pins, discovered attacks and en passant all reachable within a few plies.
+        """
+        self._assert_perft(
+            'r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1',
+            {1: 48, 2: 2039, 3: 97862},
+        )
+
+    def test_perft_position_4(self):
+        """
+        Promotion heavy, and White has already castled while Black has not, so the position
+        is only enumerated correctly if the castling field of the FEN is honoured rather
+        than inferred from where the pieces happen to stand.
+        """
+        self._assert_perft(
+            'r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1',
+            {1: 6, 2: 264, 3: 9467},
+        )
 
     def test_perft_position_3(self):
         """


### PR DESCRIPTION
Fourth of eight sequential PRs from the correctness audit. Follows #35.

**This completes the rules engine.** The remaining four PRs move to the AI.

## The bug

`_set_from_fen` parsed FEN fields 0, 1, 3, 4 and 5 — and skipped field 2, the castling availability. Rights were then inferred from where the pieces stood:

```python
Board('r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w - - 0 1').castle_flags
# 'KQkq'   — the FEN said '-'
```

Castling rights are a property of the game's **history**, not of the position. A King and Rook can stand on their original squares having already moved away and back, which forfeits the right permanently. No amount of looking at the board recovers that.

### Why it mattered beyond FEN fidelity

`ai/algorithms.py` rebuilds a fresh board from FEN for **every root move**:

```python
for move in legal_moves:
    new_board = Board(board.fen)
```

So any game where the King had stepped out and back handed the search two castling moves that the real game could no longer play. The engine was planning around a position that did not exist:

```
r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1
Ke1-e2-e1, Ke8-e7-e8          # both Kings out and back

board.castle_flags        '-'          correct
Board(board.fen)          'KQkq'       what the search saw
```

## The fix

Parse the field into `castling_rights`, then let the existing `_update_castling_rights()` narrow it to the Kings and Rooks actually on the board. That ordering means an inconsistent FEN is still corrected rather than trusted:

```python
Board('4k3/8/8/8/8/8/8/4K3 w KQkq - 0 1').castle_flags
# '-'   — claims four rights, has no Rooks
```

FENs with **no** castling field keep falling back to positional inference. Several existing tests pass two-field FENs like `'rnbqkbnr/... w'` and depend on that, so it is preserved deliberately rather than by accident — and now documented as the fallback it is.

The flag → Rook mapping lives in `game/bitboard.py` next to `BB_ORIGINAL_ROOKS`, since that is where the other castling geometry already is.

## Tests

Three of the five new tests were confirmed to **fail without the fix**:

- `test_fen_castling_field_round_trip` — all 12 flag combinations survive load → re-render
- `test_fen_castling_field_is_honoured` — `'-'` with every piece home offers no castle
- `test_fen_does_not_resurrect_lost_castling_rights` — the alpha_beta scenario above

The other two pin the fallback behaviour that must *not* change:

- `test_fen_castling_field_narrowed_to_the_board`
- `test_fen_without_castling_field_infers_from_position`

## Perft suite completed

Kiwipete and Position 4 pass either way, but both carry real castling state in their FENs (`KQkq`, `kq`) — they are only tests of anything once that field is read, which is why they land here rather than earlier.

| Position | Depth | Expected | Status |
|---|---|---|---|
| Starting position | 4 | 197,281 | ✅ |
| Kiwipete | 3 | 97,862 | ✅ **added here** |
| Position 3 | 4 | 43,238 | ✅ |
| Position 4 | 3 | 9,467 | ✅ **added here** |
| Position 5 | 3 | 62,379 | ✅ |

All five now run as committed tests, so move generation is pinned to the reference counts rather than merely known to have matched them once.

## Verification

```
$ python3 -m unittest tests.test_all
Ran 31 tests in 3.526s
OK
```

Suite runtime went from 0.9s to 3.5s, almost entirely the added perft depth. Still fast enough to run on every change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFTrYZkCWHVtFL6Lj3f7yD)_