### PR TITLE
5/8 Fix the fifty move rule and make is_game_over complete

### DIFF
--- a/game/board.py
+++ b/game/board.py
@@ -18,6 +18,7 @@ from game.constants import (
     BLACK,
 
     STARTING_STATE,
+    HALFMOVE_CLOCK_LIMIT,
 
     PieceType,
     PAWN,
@@ -491,13 +492,15 @@ class Board:
 
     @property
     def is_game_over(self):
-        has_legal_move = any(self.legal_moves)
-
-        if self.halfmove_clock >= 50:  # 50 move draw
+        # Kept in the same order as raise_if_game_over, and deliberately lazy: generating
+        # legal moves is far more expensive than any of the checks above it.
+        if self.halfmove_clock >= HALFMOVE_CLOCK_LIMIT:  # Fifty move draw
             return True
         elif self.has_insufficient_material:
             return True
-        elif not has_legal_move:  # Check/stalemate
+        elif self.has_threefold_repetition:
+            return True
+        elif not any(self.legal_moves):  # Checkmate or stalemate
             return True
         else:
             return False
@@ -854,7 +857,7 @@ class Board:
 
     def raise_if_game_over(self):
         """Raises an exception if the game is in an end state."""
-        if self.halfmove_clock >= 50:
+        if self.halfmove_clock >= HALFMOVE_CLOCK_LIMIT:
             raise FiftyMoveDraw
         elif self.has_insufficient_material:
             raise InsufficientMaterial

--- a/game/constants.py
+++ b/game/constants.py
@@ -8,6 +8,10 @@ KINGSIDE = 'kingside'
 FILE_NAMES = ["A", "B", "C", "D", "E", "F", "G", "H"]
 RANK_NAMES = ["1", "2", "3", "4", "5", "6", "7", "8"]
 
+# The fifty move rule is fifty moves by *each* player. The halfmove clock counts plies, so
+# the draw is claimable once it reaches 100.
+HALFMOVE_CLOCK_LIMIT = 100
+
 PieceType = str
 PAWN = 'p'
 ROOK = 'r'

--- a/game/exceptions.py
+++ b/game/exceptions.py
@@ -15,7 +15,7 @@ class Stalemate(Draw):
 
 
 class FiftyMoveDraw(Draw):
-    MESSAGE = "50 moves have occured without moving a pawn or taking a piece."
+    MESSAGE = "50 moves have occurred without moving a pawn or taking a piece."
 
 
 class InsufficientMaterial(Draw):

--- a/tests/test_moves.py
+++ b/tests/test_moves.py
@@ -265,6 +265,28 @@ class TestMoves(unittest.TestCase):
             _board = Board(fen)
             self.assertEqual(_board.has_insufficient_material, result)
 
+    def test_fifty_move_draw_counts_plies(self):
+        """
+        The fifty move rule is fifty moves by *each* player. The halfmove clock counts plies,
+        so the draw is only claimable once it reaches 100, not 50.
+        """
+        _board = Board('8/8/4k3/8/8/4K3/8/R7 w - - 49 80')
+        _board.make_move(Move.from_uci('a1a2'))
+        self.assertEqual(_board.halfmove_clock, 50)  # Only 25 moves each
+        self.assertFalse(_board.is_game_over)
+        _board.raise_if_game_over()  # Must not raise
+
+        _board = Board('8/8/4k3/8/8/4K3/8/R7 w - - 98 80')
+        _board.make_move(Move.from_uci('a1a2'))
+        self.assertEqual(_board.halfmove_clock, 99)
+        self.assertFalse(_board.is_game_over)
+
+        _board.make_move(Move.from_uci('e6e7'))
+        self.assertEqual(_board.halfmove_clock, 100)
+        self.assertTrue(_board.is_game_over)
+        with self.assertRaises(FiftyMoveDraw):
+            _board.raise_if_game_over()
+
     def test_threefold_repetition(self):
         _board = Board(track_repetitions=True)
         for move in (
@@ -291,9 +313,16 @@ class TestMoves(unittest.TestCase):
             _board.make_move(m)
 
         self.assertTrue(_board.has_threefold_repetition)
+
+        # is_game_over must agree with raise_if_game_over about what ends a game
+        self.assertTrue(_board.is_game_over)
+        with self.assertRaises(ThreefoldRepetition):
+            _board.raise_if_game_over()
+
         _board.unmake_move()
         _board.make_move(Move.from_uci('h2h3'))
         self.assertFalse(_board.has_threefold_repetition)
+        self.assertFalse(_board.is_game_over)
 
 
 def main():


### PR DESCRIPTION
Fifth of eight sequential PRs from the correctness audit. Follows #36. Two small independent bugs in how a game is judged to be over.

## 1. The fifty move rule fired at 25 moves

```python
if self.halfmove_clock >= 50:  # 50 move draw
```

The halfmove clock counts **plies**, and the rule is fifty moves by *each* player. Games were being drawn at exactly half the correct point:

```
halfmove_clock 50 (= 25 moves each):  is_game_over → True    ✗
```

Fixed by threshold, and the threshold is now a named constant so the unit it counts is stated rather than implied:

```python
# The fifty move rule is fifty moves by *each* player. The halfmove clock counts plies, so
# the draw is claimable once it reaches 100.
HALFMOVE_CLOCK_LIMIT = 100
```

Both `is_game_over` and `raise_if_game_over` used the bare `50` independently, which is how they stayed wrong together.

## 2. `is_game_over` and `raise_if_game_over` disagreed

`raise_if_game_over` checked five end conditions. `is_game_over` checked three, omitting **threefold repetition**. So a board could raise `ThreefoldRepetition` from one method while reporting `is_game_over == False` from the other.

```
has_threefold_repetition = True
is_game_over             = False    ✗
```

`is_game_over` now checks the same conditions in the same order as `raise_if_game_over`.

Worth being precise about the blast radius: `ai/benchmark.py`'s `simulate_game` loops on `while not b.is_game_over`, but it constructs `Board()` without `track_repetitions`, so repetition detection was off there anyway and those games still terminated on the (broken) move clock. This is a correctness fix for anyone who *does* enable tracking, not a hang fix.

## Also: `is_game_over` was doing unnecessary work

```python
has_legal_move = any(self.legal_moves)   # evaluated first...
if self.halfmove_clock >= 50:
    return True
...
elif not has_legal_move:                 # ...used last
```

Move generation is by far the most expensive thing in the class, and it was evaluated eagerly on every call even when the game was already drawn on the clock. Now evaluated lazily in the branch that needs it — 2,000 calls on a drawn position went from generating 2,000 move lists to 0.0002s total.

## Tests

Both confirmed to **fail without the fix**:

- `test_fifty_move_draw_counts_plies` — asserts not-over at 50 and 99, over at 100, and that `raise_if_game_over` stays silent at 50 and raises `FiftyMoveDraw` at 100
- `test_threefold_repetition` — extended to assert `is_game_over` agrees with `raise_if_game_over`, both when the repetition has occurred and after it is undone

## Verification

```
$ python3 -m unittest tests.test_all
Ran 32 tests in 3.346s
OK
```

Also fixes "occured" → "occurred" in the `FiftyMoveDraw` message, which is user-facing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFTrYZkCWHVtFL6Lj3f7yD)_