### PR TITLE
6/8 Score terminal search nodes against the side to move

### DIFF
--- a/ai/algorithms.py
+++ b/ai/algorithms.py
@@ -9,6 +9,32 @@ from game.board import Board, Move
 LOW_BOUND = -9999999
 HIGH_BOUND = 9999999
 
+# Score of a forced mate, kept well inside the search window so it never collides with the
+# alpha/beta bounds themselves.
+MATE = 1000000
+
+
+def _terminal_value(board: Board, depth: int, player: bool) -> int:
+    """
+    Scores a position that has no legal moves, in the same terms as the rest of the tree.
+
+    Values inside the search are positive for the opponent: _get_best_move plays the root
+    move before descending, so _alpha_beta_max nodes belong to the opponent and
+    _alpha_beta_min nodes belong to us, and the sign is flipped once at the root.
+
+    Checkmate is therefore scored against whoever is to move, which is what makes one
+    function correct at both node types. Scoring it against `player` instead is only ever
+    right at one of them, and leaves the engine unable to see mate against itself.
+
+    Deeper mates score lower, so a mate in one is preferred over a mate in five and the
+    engine does not shuffle in a won position. Stalemate is a draw and scores zero.
+    """
+    if not board.is_in_check:  # No moves and no check: stalemate, which is a draw
+        return 0
+
+    mate_score = MATE + depth  # Larger remaining depth means a mate closer to the root
+    return mate_score if board.turn == player else -mate_score
+
 
 def simple_eval(board: Board) -> int:
     return board.value
@@ -138,11 +164,8 @@ def _alpha_beta_min(board: Board, depth: int, alpha: int, beta: int, player: boo
             return best, counter
         i += 1
 
-    if i == 0:  # Game is over
-        if board.is_checkmate and board.turn != player:
-            return HIGH_BOUND + 1, counter  # Value checkmate above all else
-        else:
-            return LOW_BOUND - 1, counter   # Any other end game state is the worst case scenario
+    if i == 0:  # No legal moves: checkmate or stalemate
+        return _terminal_value(board, depth, player), counter
     return beta, counter
 
 
@@ -165,11 +188,8 @@ def _alpha_beta_max(board: Board, depth: int, alpha: int, beta: int, player: boo
             return best, counter
         i += 1
 
-    if i == 0:  # Game is over
-        if board.is_checkmate and board.turn != player:
-            return LOW_BOUND - 1, counter  # Value checkmate above all else
-        else:
-            return HIGH_BOUND + 1, counter   # Any other end game state is the worst case scenario
+    if i == 0:  # No legal moves: checkmate or stalemate
+        return _terminal_value(board, depth, player), counter
 
     return alpha, counter
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -4,6 +4,7 @@ from tests.test_board import TestBitboard
 from tests.test_moves import TestMoves
 from tests.test_undo import TestUndo
 from tests.test_permutations import TestPermutations
+from tests.test_search import TestSearch, TestTerminalValue, TestUciSearchOutput
 
 
 def main():

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,131 @@
+import io
+import unittest
+import contextlib
+
+from game.board import Board
+from game.constants import WHITE, BLACK
+from ai.algorithms import alpha_beta, _terminal_value
+from uci.engine import UciEngine
+
+
+class TestTerminalValue(unittest.TestCase):
+    """
+    Direct cover for the scoring of positions with no legal moves. Values inside the search
+    are positive for the opponent, and the sign convention is the whole of what was wrong.
+    """
+
+    # White has been mated by Qh4, and it is White to move
+    MATED = 'rnb1kbnr/pppp1ppp/4p3/8/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 0 1'
+
+    # Black to move with nowhere to go, but not in check
+    STALEMATED = '7k/5Q2/6K1/8/8/8/8/8 b - - 0 1'
+
+    def test_checkmate_is_scored_against_the_side_to_move(self):
+        board = Board(fen=self.MATED)
+        self.assertTrue(board.is_checkmate)
+
+        # We are the side being mated, which is the best possible outcome for the opponent
+        self.assertGreater(_terminal_value(board, 3, WHITE), 0)
+
+        # The opponent is the side being mated, which is the best possible outcome for us
+        self.assertLess(_terminal_value(board, 3, BLACK), 0)
+
+    def test_closer_mates_score_higher(self):
+        board = Board(fen=self.MATED)
+
+        # Remaining depth is larger nearer the root, so a shallower mate scores further from
+        # zero and wins the comparison
+        self.assertGreater(_terminal_value(board, 5, WHITE), _terminal_value(board, 3, WHITE))
+        self.assertLess(_terminal_value(board, 5, BLACK), _terminal_value(board, 3, BLACK))
+
+    def test_stalemate_scores_as_a_draw(self):
+        board = Board(fen=self.STALEMATED)
+        self.assertTrue(board.is_stalemate)
+
+        # A draw is a draw whoever is searching
+        self.assertEqual(_terminal_value(board, 3, WHITE), 0)
+        self.assertEqual(_terminal_value(board, 3, BLACK), 0)
+
+
+class TestSearch(unittest.TestCase):
+    """Tests of what the AI decides, rather than of what the rules permit."""
+
+    def test_finds_mate_in_one(self):
+        fen = '6k1/5ppp/8/8/8/8/8/R3K3 w - - 0 1'  # Ra8 is mate
+        for depth in (2, 3):
+            board = Board(fen=fen)
+            move = alpha_beta(board, depth=depth)
+            self.assertEqual(move.uci, 'a1a8', f'at depth {depth}')
+
+            board.make_move(move)
+            self.assertTrue(board.is_checkmate)
+
+    def test_avoids_forced_mate(self):
+        """
+        Black threatens Ra1 mate and the King on h1 is boxed in by its own pawns. Only a move
+        that makes luft survives it. Scoring mate against `player` rather than against the
+        side to move made this branch invisible, and the engine walked into it.
+        """
+        fen = 'r5k1/5ppp/8/8/8/8/5PPP/7K w - - 0 1'
+        for depth in (3, 4):
+            move = alpha_beta(Board(fen=fen), depth=depth)
+            self.assertIn(move.uci, {'g2g3', 'g2g4', 'h2h3', 'h2h4'}, f'at depth {depth}')
+
+            # And prove the rejected moves really do lose
+            board = Board(fen=fen)
+            board.make_move(move)
+            board.make_move('a8a1')
+            self.assertFalse(board.is_checkmate, f'at depth {depth}')
+
+    def test_prefers_the_faster_mate(self):
+        """Rc8 is mate at once. Several Queen moves mate a move later and are generated first."""
+        move = alpha_beta(Board(fen='7k/Q7/8/8/8/8/8/2R4K w - - 0 1'), depth=4)
+        self.assertEqual(move.uci, 'c1c8')
+
+    def test_prefers_a_draw_to_a_losing_position(self):
+        """
+        White is a Knight and four pawns down. Every Black pawn is blocked and the Knight on
+        b8 is pinned to the King by the Rook on h8, so a5a6 takes away the King's last flight
+        square and stalemates Black. A draw beats every other move on the board.
+        """
+        fen = 'kn5R/3p1p2/1P1p1p2/P2p1p2/3p1P2/3p4/3P4/7K w - - 0 1'
+        self.assertLess(Board(fen=fen).value, 0)  # White really is losing
+
+        move = alpha_beta(Board(fen=fen), depth=4)
+        self.assertEqual(move.uci, 'a5a6')
+
+        board = Board(fen=fen)
+        board.make_move(move)
+        self.assertTrue(board.is_stalemate)
+
+
+class TestUciSearchOutput(unittest.TestCase):
+    def _go(self, fen: str) -> str:
+        engine = UciEngine()
+        engine.set_fen(fen)
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            engine.get_best_move()
+        return output.getvalue().strip()
+
+    def test_go_reports_a_move(self):
+        self.assertTrue(self._go('6k1/5ppp/8/8/8/8/8/R3K3 w - - 0 1').startswith('bestmove '))
+
+    def test_go_with_no_legal_moves(self):
+        """
+        Searching a finished game returns no move, which used to reach `move.uci` on None and
+        kill the engine. UCI expects `bestmove (none)`.
+        """
+        self.assertEqual(
+            self._go('rnb1kbnr/pppp1ppp/4p3/8/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 0 1'),
+            'bestmove (none)',
+        )
+        self.assertEqual(self._go('7k/5Q2/6K1/8/8/8/8/8 b - - 0 1'), 'bestmove (none)')
+
+
+def main():
+    unittest.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/uci/engine.py
+++ b/uci/engine.py
@@ -92,6 +92,12 @@ class UciEngine:
             self.board.make_move(move)
 
     def get_best_move(self):
+        # Checkmate and stalemate leave nothing to search. Both search and random_move
+        # assume at least one legal move exists, so answer before calling them.
+        if not any(self.board.legal_moves):
+            out('bestmove (none)')
+            return
+
         if self.params['skill'].value == 0:
             move = random_move(self.board)
         else:


### PR DESCRIPTION
Sixth of eight sequential PRs from the correctness audit. Follows #37.

**This is the one that changes how the engine plays.** Everything so far fixed what the engine believes about the rules; this fixes what it does with that knowledge.

## The bug

Values inside the search are **positive for the opponent**. `_get_best_move` plays the root move *before* descending, so `_alpha_beta_max` nodes belong to the opponent, `_alpha_beta_min` nodes belong to us, and the sign is flipped once at the root.

Both terminal branches guarded with the same test:

```python
if board.is_checkmate and board.turn != player:
```

That can only ever be true at a **max** node — at a min node the side to move *is* `player`. So being checkmated always fell through to the `else` and returned `LOW_BOUND - 1`, meaning *"catastrophic for the opponent"*. The opponent's parent max node, which maximises, then discarded the mating move as its worst available option.

**The engine concluded that its opponent would never checkmate it.**

```
r5k1/5ppp/8/8/8/8/5PPP/7K w - - 0 1
```

```
8 [♜][ ][ ][ ][ ][ ][♚][ ]      Black threatens Ra1#.
7 [ ][ ][ ][ ][ ][♟][♟][♟]      Kh1 is boxed in by its own f2/g2/h2 pawns.
2 [ ][ ][ ][ ][ ][♙][♙][♙]      safe:   g2g3 g2g4 h2h3 h2h4
1 [ ][ ][ ][ ][ ][ ][ ][♔]      losing: f2f3 f2f4 h1g1
```

| | depth 3 | depth 4 |
|---|---|---|
| before | `h1g1` → mated | `h1g1` → mated |
| after | `h2h3` ✅ | `h2h3` ✅ |

## The fix

One shared helper that scores by **whose turn it is at that node**, which is what makes it correct at both node types:

```python
def _terminal_value(board, depth, player):
    if not board.is_in_check:   # No moves and no check: stalemate, which is a draw
        return 0
    mate_score = MATE + depth   # Larger remaining depth means a mate closer to the root
    return mate_score if board.turn == player else -mate_score
```

Three things fall out of it:

1. **Mate against the engine is visible.** The headline fix above.
2. **Stalemate is a draw.** It previously fell through the checkmate branch and was scored as a forced result, so the engine treated a draw as the worst case and would not take one when losing.
3. **Mate scores carry distance.** `MATE + depth` means a mate in one beats a mate in five, so the engine stops shuffling in won positions.

It also now tests `is_in_check` rather than `is_checkmate` — we already know there are no legal moves at that point, and `is_checkmate` regenerates the whole move list to rediscover it.

## Also fixes a crash on the only interface the project has

`UciEngine.get_best_move` formatted `move.uci` without checking a move came back, and `alpha_beta` returns `None` when there is nothing to search:

```
before:  go on a checkmated board -> CRASH: AttributeError: 'NoneType' object has no attribute 'uci'
after:   go on a checkmated board -> 'bestmove (none)'
```

I flagged this during #33 and held it for this PR, since it is squarely a terminal-node case.

## tests/test_search.py

The suite has never tested what the AI **decides** — only what the rules permit. That is precisely why this survived five years, so this PR adds the file.

| Test | Before | After |
|---|---|---|
| `test_finds_mate_in_one` | ✅ | ✅ |
| `test_avoids_forced_mate` | ❌ plays `h1g1` | ✅ |
| `test_prefers_the_faster_mate` | ✅ | ✅ |
| `test_prefers_a_draw_to_a_losing_position` | ❌ plays `h8f8` | ✅ |
| `test_go_with_no_legal_moves` | ❌ AttributeError | ✅ |

Being straight about which of these are discriminators: `test_finds_mate_in_one` and `test_prefers_the_faster_mate` pass under the old code too. They are regression guards, not proof of this fix. The two that actually failed before are the forced-mate and draw cases.

Plus three direct tests of the scoring contract itself (`TestTerminalValue`), since the sign convention is the subtle part worth pinning explicitly.

### The draw fixture

`kn5R/3p1p2/1P1p1p2/P2p1p2/3p1P2/3p4/3P4/7K w - - 0 1` — White is a Knight and four pawns down. Every Black pawn is blocked, and the Knight on b8 is pinned to the King by the Rook on h8, so `a5a6` removes the King's last flight square and stalemates Black. A draw beats every other move on the board.

Worth noting it needs **depth 4**. At depth 3 the engine still prefers a line it evaluates at +50 — the stalemate is detected and correctly scored 0, but a crude evaluation at that horizon disagrees about the alternatives. That is an evaluation limitation, not a terminal-scoring one, so the test asserts at the depth where the relevant nodes are actually in the tree.

## Verification

```
$ python3 -m unittest tests.test_all
Ran 41 tests in 3.628s
OK
```

I also re-ran all four search tests with PR 8's king piece-square table swap pre-applied, to confirm this PR's fixtures do not break when that lands. All four still pass.

## Not in this PR

`minimax` and `negamax` have no terminal-node handling at all, so they score a checkmate as plain material. Neither is reachable from the UCI path — `uci/engine.py` uses `random_move` and `alpha_beta` — and both are documented as illustrative, so fixing them is a separate concern from the search the engine actually runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFTrYZkCWHVtFL6Lj3f7yD)_