### PR TITLE
7/8 Make the promotion piece part of a move's identity

### DIFF
--- a/game/board.py
+++ b/game/board.py
@@ -697,7 +697,6 @@ class Board:
         if isinstance(move, str):
             move = Move.from_uci(move)
 
-        self._save()
         piece = self.piece_at(move.from_square)
         captured_piece = self.piece_at(move.to_square)
 
@@ -708,6 +707,13 @@ class Board:
             raise IllegalMove(f"Can't move that piece, it's not your turn.")
 
         backrank = 7 if self.turn == WHITE else 0
+
+        if piece.type == PAWN and move.to_square.rank == backrank and move.promotion is None:
+            raise IllegalMove(f"Move {move} reaches the back rank without naming a promotion piece.")
+
+        # Only now that the move is known to be playable, so a rejected move leaves no state
+        # behind for unmake_move to pop.
+        self._save()
 
         # Castling if a king is moving more than 1 square
         if piece.type == KING and abs(move.from_square.file - move.to_square.file) > 1:
@@ -737,7 +743,7 @@ class Board:
             self.place_piece(move.to_square, piece.type, piece.colour)
         elif piece.type == PAWN and move.to_square.rank == backrank:  # Promotion
             self.remove_piece(move.from_square)
-            self.place_piece(move.to_square, move.promotion, piece.colour)  # Assume queen for now
+            self.place_piece(move.to_square, move.promotion, piece.colour)
         else:
             # Regular piece move
             self.remove_piece(move.from_square)

--- a/game/move.py
+++ b/game/move.py
@@ -43,14 +43,18 @@ class Move:
     def __repr__(self) -> str:
         return f"'{str(self)}'"
 
+    # Promotion is part of a move's identity: e7e8q and e7e8r are different moves that reach
+    # different positions. __hash__ and __eq__ must agree on that, so they are kept in step.
     def __hash__(self) -> int:
         return hash((
             self.from_square,
-            self.to_square
+            self.to_square,
+            self.promotion,
         ))
 
     def __eq__(self, other) -> bool:
         return (
             other.from_square == self.from_square and
-            other.to_square == self.to_square
+            other.to_square == self.to_square and
+            other.promotion == self.promotion
         )

--- a/tests/test_moves.py
+++ b/tests/test_moves.py
@@ -226,6 +226,48 @@ class TestMoves(unittest.TestCase):
         b.make_move(Move.from_uci('g7g8q'))
         self.assertEqual(b.fen, 'rnbqr1Q1/pppp4/3k1n1p/2p1p3/3b4/8/PPPPPP1P/RNBQKBNR b KQ - 0 1')
 
+    def test_promotion_piece_is_part_of_the_move(self):
+        """
+        The four promotions of a pawn are four different moves reaching four different
+        positions, so they must not compare or hash as one.
+        """
+        self.assertNotEqual(Move.from_uci('g7g8q'), Move.from_uci('g7g8r'))
+        self.assertEqual(len({Move.from_uci(f'g7g8{p}') for p in 'qrbn'}), 4)
+
+        # Moves that are not promotions are unaffected
+        self.assertEqual(Move.from_uci('e2e4'), Move.from_uci('e2e4'))
+        self.assertEqual(len({Move.from_uci('e2e4'), Move.from_uci('e2e4')}), 1)
+
+        # And each promotion really does produce a different board
+        fen = 'rnbqr3/pppp2P1/3k1n1p/2p1p3/3b4/8/PPPPPP1P/RNBQKBNR w KQ - 0 1'
+        placements = set()
+        for piece in 'qrbn':
+            _board = Board(fen)
+            _board.make_safe_move(f'g7g8{piece}')
+            placements.add(_board.fen)
+        self.assertEqual(len(placements), 4)
+
+    def test_promotion_without_a_piece_is_rejected(self):
+        """
+        A promotion with no piece named used to pass the legality check, because equality
+        ignored the promotion, and then died inside make_move on `None.lower()`.
+        """
+        fen = 'rnbqr3/pppp2P1/3k1n1p/2p1p3/3b4/8/PPPPPP1P/RNBQKBNR w KQ - 0 1'
+
+        _board = Board(fen)
+        self.assertNotIn(Move.from_uci('g7g8'), list(_board.legal_moves))
+        with self.assertRaises(IllegalMove):
+            _board.make_safe_move('g7g8')
+
+        # make_move is the unchecked path, and must still fail meaningfully rather than
+        # with an AttributeError
+        _board = Board(fen)
+        with self.assertRaises(IllegalMove):
+            _board.make_move('g7g8')
+
+        # A rejected move must leave nothing behind for unmake_move to pop
+        self.assertEqual(len(_board._history), 0)
+        self.assertEqual(_board.fen, fen)
 
     def test_checkmate(self):
         for fen, result in (

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -122,6 +122,34 @@ class TestUciSearchOutput(unittest.TestCase):
         )
         self.assertEqual(self._go('7k/5Q2/6K1/8/8/8/8/8 b - - 0 1'), 'bestmove (none)')
 
+    def test_unplayable_move_does_not_kill_the_engine(self):
+        """
+        UCI is the only interface, so a malformed move from the GUI is reported on stderr and
+        the engine keeps answering rather than unwinding out of run().
+        """
+        engine = UciEngine()
+        engine.set_fen('rnbqr3/pppp2P1/3k1n1p/2p1p3/3b4/8/PPPPPP1P/RNBQKBNR w KQ - 0 1')
+
+        errors = io.StringIO()
+        with contextlib.redirect_stderr(errors):
+            engine.play_moves(['g7g8'])  # Promotion with no piece named
+        self.assertIn('g7g8', errors.getvalue())
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            engine.get_best_move()
+        self.assertTrue(output.getvalue().strip().startswith('bestmove '))
+
+    def test_promotion_through_uci(self):
+        """Each promotion piece named over UCI reaches a different position."""
+        placements = set()
+        for piece in 'qrbn':
+            engine = UciEngine()
+            engine.set_fen('rnbqr3/pppp2P1/3k1n1p/2p1p3/3b4/8/PPPPPP1P/RNBQKBNR w KQ - 0 1')
+            engine.play_moves([f'g7g8{piece}'])
+            placements.add(engine.board.fen)
+        self.assertEqual(len(placements), 4)
+
 
 def main():
     unittest.main()

--- a/uci/engine.py
+++ b/uci/engine.py
@@ -3,6 +3,7 @@ import sys
 from typing import Any, Optional, List
 
 from game.board import Board, Move
+from game.exceptions import IllegalMove
 from ai.algorithms import random_move, alpha_beta
 
 
@@ -88,8 +89,13 @@ class UciEngine:
 
     def play_moves(self, moves: List[str]):
         for m in moves:
-            move = Move.from_uci(m)
-            self.board.make_move(move)
+            try:
+                self.board.make_move(Move.from_uci(m))
+            except (IllegalMove, AssertionError) as e:
+                # UCI is the only interface, so a malformed move from the GUI must not take
+                # the engine down with it.
+                err(f'Could not play move {m}: {e}')
+                return
 
     def get_best_move(self):
         # Checkmate and stalemate leave nothing to search. Both search and random_move


### PR DESCRIPTION
Seventh of eight sequential PRs from the correctness audit. Follows #38.

## The bug

`game/move.py` — `__hash__` and `__eq__` compared only `from_square` and `to_square`, so all four promotions of a pawn were the same move:

```python
Move.from_uci('e7e8q') == Move.from_uci('e7e8r')     # True
{Move.from_uci(f'e7e8{p}') for p in 'qrbn'}          # collapses to ONE element
```

That left a validation hole. `make_safe_move` gates on `move in self.legal_moves`, so an under-specified `'g7g8'` matched the generated Queen promotion, **passed as legal**, and then died inside `make_move`:

```
AttributeError: 'NoneType' object has no attribute 'lower'
```

## The fix

Promotion now takes part in both `__eq__` and `__hash__` — kept in step, since changing one without the other breaks the hash/eq contract. That closes the hole at the point it should be closed: `'g7g8'` no longer matches anything in `legal_moves`.

`make_move` additionally rejects a back-rank pawn move with no piece named, raising `IllegalMove` instead of failing on `None`. **It does not default to Queen** — that would silently accept malformed UCI and hide the caller's bug.

```
before:  make_safe_move('g7g8')  ->  AttributeError: 'NoneType' object has no attribute 'lower'
after:   make_safe_move('g7g8')  ->  IllegalMove: Move g7g8 is illegal.
         make_move('g7g8')       ->  IllegalMove: Move g7g8 reaches the back rank without
                                     naming a promotion piece.
```

### This matters more since the web UI was removed, not less

`UciEngine.play_moves` feeds `Move.from_uci` straight into `make_move` with no validation of its own, and UCI is now the only interface. It now reports an unusable move on stderr and leaves the engine answering, rather than letting the exception unwind out of `run()` and kill the process:

```
$ printf 'position fen <...> moves g7g8\ngo\nquit\n' | python3 main.py
Could not play move g7g8: Move g7g8 reaches the back rank without naming a promotion piece.
bestmove e2e3
exit code: 0
```

## One thing I fixed while in there

`make_move` called `self._save()` *before* its validation, so **every** raise in that function left a state snapshot behind that a later `unmake_move` would pop — desynchronising `_history` from `move_history`. That was pre-existing (it affected the two existing `IllegalMove` raises), but adding a third raise would have made it worse, so `_save()` now happens once the move is known to be playable. There is a test asserting a rejected move leaves `_history` empty.

## Tests

Three of the four confirmed to **fail without the fix**:

| Test | Before |
|---|---|
| `test_promotion_piece_is_part_of_the_move` | ❌ four promotions hash as one |
| `test_promotion_without_a_piece_is_rejected` | ❌ AttributeError |
| `test_unplayable_move_does_not_kill_the_engine` | ❌ exception escapes `play_moves` |
| `test_promotion_through_uci` | ✅ regression guard only |

Being straight about the fourth: `play_moves` calls `make_move` directly, so a *well-formed* promotion always placed the right piece. That test guards the behaviour rather than proving the fix.

### What this does not disturb

Checked before changing equality:

- `tests/test_undo.py:128` plays `'H7H8q'` and asserts `m in board.legal_moves`. Generated promotions carry `promotion='q'`, so it still matches.
- Every other `in ... legal_moves` assertion is a non-promotion move, where both sides are `None`.

## Verification

```
$ python3 -m unittest tests.test_all
Ran 45 tests in 4.346s
OK
```

```
$ printf 'position fen <...> moves g7g8n\nd\nquit\n' | python3 main.py
8 [♜][♞][♝][♛][♜][ ][♘][ ]      <- promoted to a Knight, not a Queen
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFTrYZkCWHVtFL6Lj3f7yD)_