### PR TITLE
8/8 Select the King piece-square table by the right game phase

### DIFF
--- a/game/board.py
+++ b/game/board.py
@@ -530,12 +530,34 @@ class Board:
         return total
 
     @property
+    def is_endgame(self) -> bool:
+        """
+        Whether the game has reached an endgame, which changes where the King wants to be: it
+        shelters behind its pawns while there is material to attack it, and walks towards the
+        centre once there is not.
+
+        True once the queens are off, or once at most four minor and major pieces remain
+        between both players.
+        """
+        queens = self.queens[WHITE] | self.queens[BLACK]
+        if not queens:
+            return True
+
+        return bit_count(
+            queens |
+            self.rooks[WHITE] | self.rooks[BLACK] |
+            self.bishops[WHITE] | self.bishops[BLACK] |
+            self.knights[WHITE] | self.knights[BLACK]
+        ) <= 4
+
+    @property
     def weighted_value(self) -> int:
         """
         Weighted evaluation of the game, positive for white, negative for black. Adjusts piece values depending on the
         positions on the game. More expensive to calcualte than Board.value.
         """
         total = 0
+        king_values = KING_LATE_GAME_POSITION_VALUES if self.is_endgame else KING_POSITION_VALUES
         for colour in (WHITE, BLACK):
             modifier = 1 if colour == WHITE else -1
             for piece_type in (PAWN, ROOK, BISHOP, KNIGHT, QUEEN, KING):
@@ -555,20 +577,8 @@ class Board:
                     for sq in bitboard_to_squares(self.queens[colour]):
                         total += ((PIECE_VALUES[piece_type] + QUEEN_POSITION_VALUES[colour][sq]) * modifier)
                 elif piece_type == KING:
-                    if (
-                        not (self.queens[WHITE] | self.queens[BLACK]) or
-                        bit_count(
-                            self.queens[WHITE] | self.queens[BLACK] |
-                            self.rooks[WHITE] | self.rooks[BLACK] |
-                            self.bishops[WHITE] | self.bishops[BLACK] |
-                            self.knights[WHITE] | self.knights[BLACK]
-                        ) <= 4
-                    ):
-                        pos_values = KING_POSITION_VALUES
-                    else:
-                        pos_values = KING_LATE_GAME_POSITION_VALUES
                     for sq in bitboard_to_squares(self.kings[colour]):
-                        total += ((PIECE_VALUES[piece_type] + pos_values[colour][sq]) * modifier)
+                        total += ((PIECE_VALUES[piece_type] + king_values[colour][sq]) * modifier)
         return total
 
     @property

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -96,6 +96,9 @@ class TestBitboard(unittest.TestCase):
             self.assertEqual(_board.value, val)
 
     def test_weighted_value(self):
+        # Note these cannot detect which King table is in use: all three place the Kings on
+        # e1 and e8, which are mirror squares, so the two King terms cancel exactly whichever
+        # table is selected. See test_king_position_by_game_phase.
         for fen, val in (
             (STARTING_STATE, 0),
             ('rn1qk3/p1p1p3/8/3Q4/8/8/PPPPPP1P/RNBQKBNR b - - 0 1', 2730),
@@ -103,6 +106,39 @@ class TestBitboard(unittest.TestCase):
         ):
             _board = Board(fen=fen)
             self.assertEqual(_board.weighted_value, val)
+
+    def test_is_endgame(self):
+        for fen, result in (
+            (STARTING_STATE, False),
+            ('rn1qk3/p1p1p3/8/3Q4/8/8/PPPPPP1P/RNBQKBNR b - - 0 1', False),
+            ('rnb1kbnr/pppppppp/8/8/8/8/PPPPPPPP/RNB1KBNR w - - 0 1', True),  # Queens off
+            ('4k3/8/8/8/8/8/8/2BQK1N1 w - - 0 1', True),  # Queen on, but only four pieces
+            ('8/8/8/4k3/8/8/8/R6K w - - 0 1', True),  # King and Rook against a King
+        ):
+            self.assertEqual(Board(fen=fen).is_endgame, result, fen)
+
+    def test_king_position_by_game_phase(self):
+        """
+        The King wants opposite things in each phase, so the two piece-square tables must not
+        be selected the wrong way round. Each pair below is identical in material and differs
+        only in where the White King stands.
+
+        Orderings are asserted rather than totals: the tables are tuning constants, and
+        pinning their sums would break on any retune.
+        """
+        # Endgame: no queens, so the King should walk towards the centre
+        centralised = Board(fen='8/8/8/4k3/4K3/8/8/R7 w - - 0 1')
+        cornered = Board(fen='8/8/8/4k3/8/8/8/R6K w - - 0 1')
+        self.assertTrue(centralised.is_endgame)
+        self.assertGreater(centralised.weighted_value, cornered.weighted_value)
+
+        # Opening: queens and a full board, so the King should stay tucked away instead
+        tucked = Board(fen='rn2k3/8/8/8/8/8/8/RN1Q2KR w - - 0 1')
+        exposed = Board(fen='rn2k3/8/8/8/3K4/8/8/RN1Q3R w - - 0 1')
+        self.assertFalse(tucked.is_endgame)
+        self.assertEqual(tucked.value, exposed.value)  # Same material, only the King moved
+        self.assertGreater(tucked.weighted_value, exposed.weighted_value)
+
 
 def main():
     unittest.main()


### PR DESCRIPTION
Last of eight sequential PRs from the correctness audit. Follows #39.

## The bug

The condition in `weighted_value` is the **endgame** test — no queens, or at most four minor and major pieces. It selected `KING_POSITION_VALUES`, the **opening** table that rewards tucking into a corner, and the `else` selected the late-game table that rewards centralisation.

The two are the wrong way round, so the King is evaluated backwards in **both** phases — not only in endgames, which is how I first described it. Each pair below is identical in material and differs only in where the White King stands:

| | before | after |
|---|---|---|
| **endgame** (K+R vs K, no queens) | | |
| King centralised on e4 | +500 | +500 |
| King cornered on h1 | **+560** | **+410** |
| *centralised preferred?* | **no** ✗ | **yes** ✓ |
| **opening** (full material, queens on) | | |
| King tucked on g1 | +1395 | +1425 |
| King centralised on d4 | **+1465** | **+1355** |
| *tucked preferred?* | **no** ✗ | **yes** ✓ |

The engine wanted its King in the corner during an endgame and marching up the board during the opening.

## The fix

Swap the branches, and extract the condition to an `is_endgame` property named after the concept it encodes:

```python
@property
def is_endgame(self) -> bool:
    queens = self.queens[WHITE] | self.queens[BLACK]
    if not queens:
        return True
    return bit_count(queens | rooks | bishops | knights) <= 4
```

It was an eight-line inline boolean, which is a large part of why the inversion was hard to see. It also sat *inside* `for colour in (WHITE, BLACK)` despite being colour-independent, so it was evaluated twice per call — in the function the search runs at every leaf. The table is now selected once, before the loop.

## Why the existing test couldn't catch this

`test_weighted_value` keeps its expectations — `0`, `2730`, `-3120` — **completely unchanged**, and that is the interesting part.

All three of its positions place the Kings on **e1 and e8, which are mirror squares**. `KING_POSITION_VALUES[WHITE]` is the vertically mirrored base table and `[BLACK]` is the base table, so mirrored placements contribute equal and opposite terms that cancel **exactly** — whichever table is selected. The test is structurally blind to King placement, sitting right next to a name that suggests it covers evaluation.

I've left a comment on it saying so, pointing at the new test.

## The new test

`test_king_position_by_game_phase` asserts **orderings** between asymmetric positions rather than totals. The piece-square tables are tuning constants; a test pinning their sums would break on any retune and would be testing arithmetic rather than behaviour.

One fixture note: the opening pair is hand-built. A FEN with a genuinely castled King silently drops a bishop and a knight from the back rank, so the obvious comparison is dominated by material — my first attempt scored -600 vs +70 and measured nothing useful. Both fixtures here have 8 pieces and a material value of +1400, asserted in the test itself.

Also adds `test_is_endgame` covering both arms of the condition (queens off; queens on but few pieces).

### Both assertions confirmed load-bearing

Stashing the whole file only proves the property is missing, so I reverted *just the table selection* while keeping `is_endgame` in place:

```
with the fix as committed:       endgame_ok=True   opening_ok=True
with the old selection restored: endgame_ok=False  opening_ok=False
```

## Verification

```
$ python3 -m unittest tests.test_all
Ran 47 tests in 4.271s
OK
```

Speed: an A/B in the same session, since this touches the evaluation the search calls at every leaf. An earlier run showed perft at 103k against a ~120k baseline, but perft never calls `weighted_value`, so I measured both branches back to back rather than assuming:

```
[master ] perft(4) median 102,614 nodes/s
[this PR] perft(4) median 102,665 nodes/s
```

Identical — the drop from the historical ~120k is container load, not this change. `alpha_beta` at depth 4 from the opening runs in 0.18s.

---

## This completes the audit

| PR | Fix |
|---|---|
| #33 | Narrowed to chess; engine made runnable via UCI (`UciEngine` was dead code) |
| #34 | Castling with a captured Rook — created material from nothing |
| #35 | En passant discovered check — the last move-generation defect |
| #36 | FEN castling field ignored; the search hallucinated lost rights |
| #37 | Fifty-move rule fired at 25 moves; `is_game_over` was incomplete |
| #38 | Search was blind to its own checkmate |
| #39 | All four promotions compared as one move |
| #40 | King evaluated backwards in both game phases |

Move generation matches the published perft counts on all five standard positions. The test suite went from 19 tests to 47, and now covers what the AI *decides*, not only what the rules permit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFTrYZkCWHVtFL6Lj3f7yD)_