### PR TITLE
Compare copies by what a caller can see, not by what they expose

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,29 @@ It did change `games/base.py` twice, though, and honestly rather than not:
   under test stops one move before the position that breaks it. That is exactly how it survived
   Connect 4 being added.
 
+The audit that followed found the same shape of mistake once more, in `ChessBoard.copy`. It
+rebuilt the board from its FEN, which carries castling rights, the en passant square and both
+clocks — but not how many times a position has occurred. So a copy of a game drawn by threefold
+repetition had the **same `signature` as the original and was still running**, which is precisely
+what `GameState.signature` promises cannot happen. Nothing enabled `track_repetitions` outside one
+test, so it never bit; but copies are not incidental — `alpha_beta` takes one per root move and
+`ai/match.py` plays every game on one.
+
+Both bugs are the same failure, and it is worth naming because it is not a coding mistake:
+
+> **The test's notion of "the same" was weaker than the behaviour that mattered.**
+
+`any(moves)` asked whether a move was truthy when the question was whether one existed.
+`test_copy_is_equal_and_independent` compared a copy on `_identity`, which is built from
+`signature`, so anything `signature` omitted was invisible to it by construction. In both cases
+the suite was thorough about the wrong equality.
+
+The fix in both cases is to compare what a caller can actually *observe* rather than what the
+implementation happens to expose, which is what `test_a_copy_is_interchangeable_with_its_original`
+now does — moves, both halves of the result, and the turn. That also gives `copy` a real
+definition of what it may leave behind: anything invisible to that test. `move_history` qualifies,
+being read only by `pgn_uci`; the repetition history never did.
+
 ## Benchmarks
 
 Move generation, measured on a 4-core container with CPython 3.11:

--- a/games/chess/board.py
+++ b/games/chess/board.py
@@ -1,7 +1,7 @@
 from typing import Dict, Optional, Union
 
 import log
-from games.base import GameState, Outcome, DRAW, win
+from games.base import GameState, Outcome, DRAW, has_moves, win
 from games.chess.evaluation import weighted_eval
 from games.chess.bitboard import *
 from games.chess.move import Move
@@ -86,7 +86,7 @@ class ChessBoard(GameState):
 
     @property
     def _bb_en_passant(self):
-        return BB_SQUARES[self.en_passant_sq] if self.en_passant_sq else BB_EMPTY
+        return BB_SQUARES[self.en_passant_sq] if self.en_passant_sq is not None else BB_EMPTY
 
     @property
     def _short_fen(self):
@@ -414,7 +414,7 @@ class ChessBoard(GameState):
                 fen_str += str(blank_counter)
 
         _turn = 'w' if self.turn == WHITE else 'b'
-        _en_passant = '-' if not self.en_passant_sq else str(self.en_passant_sq).lower()
+        _en_passant = '-' if self.en_passant_sq is None else str(self.en_passant_sq).lower()
         fen_str += f' {_turn} {self.castle_flags} {_en_passant} {self.halfmove_clock} {self.fullmoves}'
 
         return fen_str
@@ -449,11 +449,11 @@ class ChessBoard(GameState):
 
     @property
     def is_checkmate(self):
-        return self.is_in_check and not any(self.legal_moves)
+        return self.is_in_check and not has_moves(self.legal_moves)
 
     @property
     def is_stalemate(self):
-        return not self.is_in_check and not any(self.legal_moves)
+        return not self.is_in_check and not has_moves(self.legal_moves)
 
     @property
     def outcome_without_moves(self) -> Outcome:
@@ -494,11 +494,22 @@ class ChessBoard(GameState):
 
     def copy(self) -> 'ChessBoard':
         """
-        A board at the same position, built from the FEN so it carries none of the history
-        that only `unmake_move` would want. That is what the root workers need, and it is
-        cheaper than snapshotting the move stack.
+        A board at the same position, built from the FEN so it carries none of the history that
+        only `unmake_move` would want. That is what the root workers need, and it is cheaper
+        than snapshotting the move stack.
+
+        The repetition history is the exception, and has to come too. It is not a record of
+        where the board has been - it is part of where the board can go, because a position
+        seen twice already is a draw the moment it appears again. A copy without it has the
+        same FEN and so the same `signature`, and finishes a different game: it was the one
+        thing `signature` promised could not happen.
+
+        `move_history` is genuinely only a record, being read by `pgn_uci` and nothing else, so
+        it stays behind.
         """
-        return ChessBoard(self.fen)
+        board = ChessBoard(self.fen, track_repetitions=self.track_repetitions)
+        board.repetitions = list(self.repetitions)
+        return board
 
     @property
     def has_insufficient_material(self):
@@ -559,7 +570,7 @@ class ChessBoard(GameState):
             return DRAW
         elif self.has_threefold_repetition:
             return DRAW
-        elif not any(self.legal_moves):  # Checkmate or stalemate
+        elif not has_moves(self.legal_moves):  # Checkmate or stalemate
             return self.outcome_without_moves
         else:
             return None

--- a/games/chess/uci/engine.py
+++ b/games/chess/uci/engine.py
@@ -2,6 +2,7 @@ import re
 import sys
 from typing import Any, Optional, List
 
+from games.base import has_moves
 from games.chess.board import ChessBoard, Move
 from games.chess.exceptions import IllegalMove
 from ai.search import random_move, alpha_beta
@@ -100,7 +101,7 @@ class UciEngine:
     def get_best_move(self):
         # Checkmate and stalemate leave nothing to search. Both search and random_move
         # assume at least one legal move exists, so answer before calling them.
-        if not any(self.board.legal_moves):
+        if not has_moves(self.board.legal_moves):
             out('bestmove (none)')
             return
 

--- a/tests/chess/test_moves.py
+++ b/tests/chess/test_moves.py
@@ -366,6 +366,47 @@ class TestMoves(unittest.TestCase):
         self.assertFalse(_board.has_threefold_repetition)
         self.assertFalse(_board.is_game_over)
 
+    def test_a_copy_keeps_the_repetition_history(self):
+        """
+        A regression. `copy` rebuilt the board from its FEN, and a FEN carries castling rights,
+        the en passant square and both clocks - but not how many times a position has occurred.
+        So a copy of a game drawn by repetition had the *same signature* as the original and was
+        still running, which is the one thing `GameState.signature` promises cannot happen.
+
+        It mattered because copies are not incidental: `alpha_beta` takes one per root move and
+        `ai.match` plays every game on one. Nothing enabled `track_repetitions` outside this
+        file, so it never bit - but "no caller currently passes True" is not the same as correct,
+        and the shared suite could not see it because a copy compared equal on every field it
+        knew to look at.
+        """
+        _board = ChessBoard(track_repetitions=True)
+        for move in ('B1C3', 'B8C6', 'C3B1', 'C6B8') * 3:
+            _board.make_move(Move.from_uci(move))
+
+        self.assertTrue(_board.has_threefold_repetition, 'the fixture should be a drawn game')
+
+        clone = _board.copy()
+        self.assertEqual(_board.signature, clone.signature, 'the same position by any measure')
+        self.assertTrue(clone.track_repetitions, 'the copy stopped tracking')
+        self.assertTrue(clone.has_threefold_repetition)
+        self.assertEqual(_board.result, clone.result)
+        self.assertEqual(_board.is_game_over, clone.is_game_over)
+
+    def test_a_copy_leaves_the_move_history_behind(self):
+        """
+        The other half of the rule, so the fix above is not read as "copy everything". A copy may
+        drop anything a caller cannot observe, and `move_history` is only read by `pgn_uci` - it
+        is a record of where the board has been, where the repetition history is part of where
+        the board may still go.
+        """
+        _board = ChessBoard()
+        _board.make_move(Move.from_uci('e2e4'))
+
+        clone = _board.copy()
+        self.assertEqual([], clone.move_history)
+        self.assertEqual(_board.signature, clone.signature)
+        self.assertEqual(_board.result, clone.result)
+
 
 def main():
     unittest.main()

--- a/tests/conformance.py
+++ b/tests/conformance.py
@@ -180,6 +180,36 @@ class GameConformanceTests:
             self.assertNotEqual(before, self._identity(clone), 'the copy did not actually move')
             self.assertEqual(before, self._identity(state), 'mutating a copy moved the original')
 
+    def test_a_copy_is_interchangeable_with_its_original(self):
+        """
+        Stronger than the test above, and deliberately not built on `_identity`.
+
+        `_identity` is `signature` plus the move list, so a copy that drops something
+        `signature` does not mention is *equal* to its original and does not *behave* like it.
+        Chess did exactly that: `copy` rebuilt the board from its FEN, which carries castling,
+        en passant and the clocks but not the repetition history, so a copy of a drawn game had
+        the same signature and was still running.
+
+        This compares what a caller can actually observe instead - the moves, both halves of the
+        result, and whose turn it is. Anything a copy is allowed to leave behind must be
+        invisible here, which is the real definition of what `copy` may drop.
+        """
+        for state in self._walk(seed=5):
+            clone = state.copy()
+            self.assertEqual(
+                self._observable(state), self._observable(clone), f'the copy differs\n{state}',
+            )
+
+    @staticmethod
+    def _observable(state: GameState):
+        """What a caller can see. Two states equal here have to be interchangeable."""
+        return (
+            sorted(str(move) for move in state.legal_moves),
+            str(state.outcome),
+            str(state.result),
+            state.turn,
+        )
+
     def test_decided_games_report_their_result(self):
         for state, expected in self.decided_games():
             self.assertEqual(expected, state.result, str(state))


### PR DESCRIPTION
A follow-up audit after the falsy-move bug in `GameState.result` that #44 fixed.

That bug was not really a typo. `any(moves)` asked whether a move was *truthy* when the question
was whether one *existed*, and it survived Connect 4 being added despite a suite that looked
thorough. So the question worth answering was not "is it fixed" but **"is the same shape of
mistake anywhere else"**.

It was, once.

## The finding: `ChessBoard.copy`

`copy` rebuilt the board from its FEN. A FEN carries castling rights, the en passant square and
both clocks — but not how many times a position has occurred. So a copy of a game drawn by
threefold repetition had the **same signature as its original and was still running**:

```
FEN identical        : True
signature identical  : True
result original      : Draw
result copy          : None
is_game_over original: True
is_game_over copy    : False
```

That is the one thing `GameState.signature` promises cannot happen — *"Two states with the same
signature must be the same position to play from."*

It never bit, because nothing outside `tests/chess/test_moves.py` enables `track_repetitions`. But
"no caller currently passes `True`" is not the same as correct, and copies are not incidental:
`alpha_beta` takes one per root move and `ai/match.py` plays **every** game on one. Had anyone
turned repetition tracking on, matches would have silently stopped scoring repetition draws.

## Why the suite could not see it — and could not see the first one either

Both bugs are the same failure, and it is worth naming because it is not a coding mistake:

> **The test's notion of "the same" was weaker than the behaviour that mattered.**

| | What the test asked | What actually mattered |
|---|---|---|
| `result` | Is any move *truthy*? | Does any move *exist*? |
| `copy` | Is the copy equal on `_identity`? | Does the copy *behave* the same? |

`_identity` is `signature` plus the move list, so anything `signature` omits was invisible to
`test_copy_is_equal_and_independent` **by construction**. The suite was not thin — it was thorough
about the wrong equality. Compounding it, its walks drove themselves by `is_game_over`, so a walk
stops one move *before* the position that breaks `is_game_over`.

## The fix

`test_a_copy_is_interchangeable_with_its_original` compares what a caller can actually observe —
the moves, both halves of the result, and the turn — rather than what the implementation happens
to expose. Deliberately **not** built on `_identity`.

That also gives `copy` a real definition of what it may leave behind, rather than a list to
remember: *anything invisible to that test*. `move_history` qualifies, being read only by
`pgn_uci`. The repetition history never did. Both now have a test saying so, and the regression
test was verified by reverting the fix and watching it fail.

## What came back clean

Recorded because a negative result that is not written down gets re-run:

- An independent harness re-checked unmake fidelity, copy interchangeability, move-list stability
  and the result contract across all three games — fingerprinting states from **raw attributes**
  rather than through `signature`, and walking by `legal_moves` rather than by `is_game_over`. No
  further findings.
- `Colour` is a `bool` with `BLACK = False`, and piece types could have been falsy. Every
  comparison turned out to be an explicit `== WHITE` / `== BLACK`.
- En passant squares are `Square(int)`, so a1 **would** be falsy — but an en passant square only
  ever sits on rank 3 or 6 (verified over random play). Latent rather than live, and now written
  as `is not None` regardless.

## Two judgement calls, flagged rather than acted on

- **`alpha_beta` returns `None`** for a position with no legal moves, and returns a move for a
  position already won. Every call site — `play.py`, `run_engine.py`, the UCI server — guards on
  `is_game_over` or an explicit move check first, so this is a sharp edge rather than a bug.
  Tightening it means changing the search's contract, which seemed worth raising rather than
  doing on a hunch.
- Chess kept using `any(self.legal_moves)` in its own `result` override and in the UCI server, so
  #44's `has_moves` fix never actually ran for chess. Safe only because a `Move` has no
  `__bool__` — which is not a property the contract asks for. Both now use `has_moves`; this one
  *was* changed, being the identical predicate rather than a new decision.

## Verification

```bash
python3 -m unittest tests.test_all -v    # 312 tests, ~18s
```

Both new regression tests were confirmed to fail with their fix reverted, which is the only thing
that shows a regression test is one. The UCI server still answers `bestmove g1f3` from the start
position after two moves, since `engine.py` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4qz6h7S61wio5RgkbGkEm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4qz6h7S61wio5RgkbGkEm)_