### PR TITLE
Place a player on a ladder of opponents, from level openings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ python3 -m unittest tests.test_all -v     # run the test suite
 python3 play.py                           # play any of the three games in the terminal
 python3 -m games.chess.uci                # start the UCI engine on stdin
 python3 zero.py benchmark --player minimax:9   # grade a player against perfect play
+python3 zero.py --game connect4 ladder --player minimax:4   # place it against a set of opponents
 ```
 
 The learned player is the one exception to "nothing to install", and it is opt-in:
@@ -107,6 +108,7 @@ Search time grows steeply with depth — see the benchmarks below.
 | `ai/search.py` | Negamax with alpha-beta pruning, and a random mover |
 | `ai/perft.py`, `ai/simulate.py` | Move enumeration, and playing two move-choosers off |
 | `ai/match.py` | Playing them off a few hundred times, which is how an evaluation is judged |
+| `ai/ladder.py` | Placing a player against a fixed sequence of opponents — can it be beaten |
 | `ai/oracle.py` | Exact play, and grading any player against it over a set of positions |
 | `ai/corpus.py` | Reading positions whose exact value was computed once and written down |
 | `ai/generate.py` | Choosing those positions, and getting the answers from an external solver |
@@ -711,6 +713,84 @@ harmless, because the mirror cancels — but an *inconsistent* one is fatal, and
 mapping the input and not the output breaks 219 of the 280 pinned positions, exactly the ones whose
 optimal set is asymmetric.
 
+### Can it be beaten? The match ladder
+
+Grading against the corpus asks whether a player **knows** the game. It is a different question
+from whether the player **can be beaten**, and the two come apart sharply in one direction: the
+tic-tac-toe network is wrong in 77 positions and is still unbeatable, because a player that does
+not blunder on the path it walks never arrives at the positions it would get wrong.
+
+Tic-tac-toe answers the second question exhaustively — `play_every_line` plays every line an
+opponent could take it down. That is exponential in the length of a game, so Connect 4 gets the
+affordable substitute: a fixed sequence of opponents, a fixed number of games against each.
+
+```
+$ python3 zero.py --game connect4 ladder --player minimax:4
+```
+
+| Challenger | `random` | `minimax:1` | `:2` | `:3` | `:4` | `:5` | `:6` | Highest beaten |
+|---|---|---|---|---|---|---|---|---|
+| `random` | 0.460 | 0.050 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | **none** |
+| `minimax:2` | 1.000 | 0.925 | 0.500 | 0.535 | 0.510 | 0.275 | 0.390 | **`minimax:1`** |
+| `minimax:4` | 1.000 | 0.935 | 0.490 | 0.640 | 0.500 | 0.405 | 0.315 | **`minimax:3`** |
+
+100 games per rung, about two minutes for the lot. Every rung is played even after a bad loss, so
+two runs are always directly comparable — tracking a player over time is most of what this is for.
+
+**A deterministic player scores exactly 0.500 against itself**, on the diagonal above, and that is
+arithmetic rather than luck: both games of a pair start from the same opening and are played by the
+same function, so they run identically and the pair is one win and one loss. It is the invariant
+the whole harness is pinned to — anything else means the pairing or the colour assignment is broken.
+
+The summary also **flags a ladder that is not clean**. `minimax:4` beats depth 3 but not depth 2,
+so it reports both rather than quoting the higher number. Connect 4 has genuine odd/even depth
+effects and the position benchmark agrees they are real, so that is worth seeing rather than
+smoothing.
+
+#### Two things about the openings, both measured
+
+Every player here is deterministic, so two games from the same position are the same game move for
+move. All the variety comes from starting a few random plies in — which makes how those openings
+are chosen the whole design.
+
+**They must be distinct.** `ai/match.py` draws them at random *with replacement*, which at its
+defaults gives **30 distinct openings for 50 pairs** of Connect 4 — one appearing four times. Forty
+per cent of a "100-game" match is the same games replayed, while the standard error still divides
+by 100 and understates itself by about 1.3×. The ladder draws from `ai/oracle.py`'s `openings_at`
+instead, which enumerates every distinct position at a ply, and **raises rather than repeating**.
+
+**They must be level.** Most openings are already won for somebody — 920 of Connect 4's 1,120 at
+four plies — and a pair from a decided opening is forced to 0.5 as soon as both players convert it.
+Those pairs go quiet exactly when the players get good enough to be worth telling apart. Starting
+only from drawn positions was measured over the same 50 pairs:
+
+| | all openings | drawn only |
+|---|---|---|
+| `minimax:2` vs `minimax:6` | 0.425 ± 0.045 *(noise)* | **0.390 ± 0.042 *(significant)*** |
+| `minimax:4` vs `minimax:6` | 0.390 ± 0.044 | **0.315 ± 0.041** |
+
+A comparison that could not be told from noise becomes one that can. `minimax:2` against
+`minimax:4` stays level either way — those two really are close, and the position benchmark says so
+independently. Connect 4 looks its openings up in the corpus, which is how it knows the value of a
+position four plies in that its own solver cannot reach; tic-tac-toe just solves them.
+
+The control that says all this works is a **perfect** player on tic-tac-toe:
+
+```
+$ python3 zero.py ladder --player minimax:9
+
+  opponent                         score  record             verdict
+  random                  0.935 +/- 0.017  +87 =13 -0         beats
+  minimax:1               0.810 +/- 0.024  +62 =38 -0         beats
+  minimax:2               0.510 +/- 0.007  +2 =98 -0          level
+  minimax:9               0.500 +/- 0.000  +0 =100 -0         level
+```
+
+**Zero losses on every rung**, which is what perfect play must produce and is the strongest single
+check on the harness. Under the earlier unbalanced ladder the same player "lost" 21 games to
+`minimax:1` — not blunders, just lost openings it had been handed. It also never *beats* the strong
+rungs, because from a level tic-tac-toe position nobody can: 100 draws out of 100 against itself.
+
 ### What alpha-beta and move ordering are worth
 
 Leaves reached from the empty Connect 4 board, all three searching the same tree:
@@ -803,6 +883,7 @@ python3 -m unittest tests.connect4.test_conformance -v      # connect 4 against 
 python3 -m unittest tests.connect4.test_evaluation -v       # symmetry, bounds and threat masks
 python3 -m unittest tests.connect4.test_solver -v           # the exact solver against 280 pinned answers
 python3 -m unittest tests.connect4.test_corpus -v           # the solved corpus, checked against itself
+python3 -m unittest tests.connect4.test_ladder -v           # the ladder, and its self-play identity
 
 python3 -m unittest tests.tictactoe.test_perfect_play -v    # the engine against an independent solver
 python3 -m unittest tests.tictactoe.test_permutations -v    # perft, and the published game census

--- a/ai/generate.py
+++ b/ai/generate.py
@@ -44,6 +44,7 @@ from typing import Dict, Iterator, List, Optional, Sequence, Set, Tuple
 
 import log
 from ai.corpus import Entry, format_entry
+from ai.oracle import openings_at
 from ai.search import alpha_beta
 from games.base import has_moves
 from games.connect4.board import Connect4
@@ -75,26 +76,20 @@ def enumerate_openings(last_ply: int = ENUMERATED_TO) -> List[List[int]]:
     """
     Every distinct position from the empty board out to `last_ply` discs.
 
-    Breadth-first and deduplicated on `solver_key` at every level, which is what keeps this finite:
-    there are 7^6 = 117,649 ways to play six moves but only 16,422 positions they reach, because
-    the order columns are played in mostly does not matter.
+    Deduplicated at every level, which is what keeps this finite: there are 7^6 = 117,649 ways to
+    play six moves but only 16,422 positions they reach, because the order columns are played in
+    mostly does not matter.
+
+    The walk itself is `ai.oracle.openings_at`, which is generic and is also what supplies match
+    openings to `ai.ladder` - the two wanted the same thing for different reasons, and one of them
+    having a private copy of it is how the two would drift apart.
     """
-    frontier: Dict[int, List[int]] = {Connect4().solver_key: []}
-    found = [[]]  # type: List[List[int]]
-
-    for ply in range(1, last_ply + 1):
-        nxt: Dict[int, List[int]] = {}
-        for moves in frontier.values():
-            state = Connect4(moves)
-            for column in list(state.legal_moves):
-                state.make_move(column)
-                if state.solver_key not in nxt:
-                    nxt[state.solver_key] = state.columns_played
-                state.unmake_move()
-
-        frontier = nxt
-        found.extend(nxt.values())
-        log.info(f'  ply {ply}: {len(nxt)} distinct positions')
+    found: List[List[int]] = []
+    for ply in range(last_ply + 1):
+        level = openings_at(Connect4, ply)
+        found.extend(state.columns_played for state in level)
+        if ply:
+            log.info(f'  ply {ply}: {len(level)} distinct positions')
 
     return found
 

--- a/ai/ladder.py
+++ b/ai/ladder.py
@@ -1,0 +1,275 @@
+"""
+How strong a player is, said in games rather than in positions.
+
+There are two questions worth asking about a player and they are not the same one. `ai.oracle`
+asks whether it **knows the game** - every position, graded against the exact answer. This asks
+whether it **can be beaten**, which is what anyone actually wants to know, and the two come apart
+sharply: the tic-tac-toe network was wrong in 77 positions and still unbeatable, because a player
+that does not blunder on the path it walks never arrives at the positions it would get wrong.
+
+Tic-tac-toe answers the second question exhaustively - `ai.oracle.play_every_line` plays every line
+an opponent could take it down. That is exponential in the length of a game, so Connect 4 cannot
+have it, and this is the affordable substitute: a fixed sequence of opponents of increasing
+strength, a fixed number of games against each, one table.
+
+Deliberately coarse. It is not trying to be the precise instrument - the solved corpus already is
+one - it is trying to say roughly how strong a player is, reproducibly, in a way that can be
+compared with the same measurement taken a week later.
+
+**Every rung is played, always.** Stopping at the first bad loss would be cheaper and would match
+the metaphor, but two runs would then have played different opponents and could not be put side by
+side. Tracking a player over time is most of what this is for, and the whole ladder is about two
+minutes.
+
+Two things about the openings do most of the work here, and both were measured rather than assumed.
+
+**They are distinct.** A minimax player and a trained network are both deterministic, so two games
+from the same position are the same game move for move; the variety comes entirely from starting a
+few random plies in. `ai.match.play_match` draws those at random *with replacement*, which at its
+defaults gives about thirty distinct openings for fifty pairs of Connect 4 - so nearly half the
+games are replays that pad the tally without informing it. The ladder draws from
+`ai.oracle.openings_at` instead, which enumerates every distinct position at a given ply, and it
+**raises rather than repeating** if there are not enough.
+
+**They are level.** Most openings are already won for somebody - 920 of Connect 4's 1,120 at four
+plies - and a pair played from a decided opening is forced to 0.5 whenever both players convert it,
+so those pairs stop saying anything as players improve. Starting only from drawn positions turned
+`minimax:2` against `minimax:6` from a result indistinguishable from noise into a significant one.
+See `balanced_openings`.
+"""
+
+import random
+from typing import Callable, List, NamedTuple, Optional, Sequence, Tuple, Type
+
+import log
+from ai.match import MatchResult, play_match
+from ai.oracle import openings_at, solve
+from ai.players import describe, player
+from games.base import GameState
+
+# Games per rung. Each opening is played twice with the sides swapped, so this is half as many
+# distinct games - 50 of them, for a standard error of about 0.04 on each rung's score.
+GAMES = 100
+
+
+class Ladder(NamedTuple):
+    """The opponents a game is measured against, and where its games start."""
+
+    rungs: Tuple[str, ...]
+    opening_plies: int
+
+    # Whether to start only from openings that are drawn with perfect play. See `balanced_openings`.
+    balanced: bool = True
+
+
+# The default sequence per game. Deterministic and fixed: a ladder that changed between runs would
+# make its own numbers incomparable, which is the one thing it must not do.
+#
+# Connect 4 stops at depth 6 because that is the last cheap rung - a full self-play game costs
+# 0.69s at depth 6 against 4.27s at depth 7, six times the price for one more ply. Its games start
+# four plies in, where 1,120 distinct openings exist; two plies would allow only 49 and so cap an
+# honest ladder at 98 games. Starting four discs down costs nothing that matters here, because the
+# corpus already grades plies 0-6 exhaustively.
+#
+# Tic-tac-toe runs to depth 9, which is perfect play, so its top rung is a control rather than an
+# opponent: a challenger that is also perfect must draw it. Three opening plies, because the whole
+# game is nine and two plies leave only 24 drawn openings - one short of the 50 a full ladder needs.
+LADDERS = {
+    'Connect4': Ladder(
+        rungs=('random', 'minimax:1', 'minimax:2', 'minimax:3', 'minimax:4', 'minimax:5',
+               'minimax:6'),
+        opening_plies=4,
+    ),
+    'TicTacToe': Ladder(
+        rungs=('random', 'minimax:1', 'minimax:2', 'minimax:3', 'minimax:4', 'minimax:9'),
+        opening_plies=3,
+    ),
+}
+
+
+class Rung(NamedTuple):
+    """One opponent, and how the challenger did against it."""
+
+    spec: str
+    result: MatchResult
+
+    @property
+    def beaten(self) -> bool:
+        """Whether the challenger is *shown* to be better, rather than merely ahead."""
+        return self.result.score > 0.5 and self.result.is_significant
+
+    @property
+    def lost(self) -> bool:
+        return self.result.score < 0.5 and self.result.is_significant
+
+    @property
+    def verdict(self) -> str:
+        return 'beats' if self.beaten else ('loses' if self.lost else 'level')
+
+
+class Standing(NamedTuple):
+    """Where a player sits on the ladder."""
+
+    rungs: List[Rung]
+    games: int
+    opening_plies: int
+    balanced: bool = True
+
+    @property
+    def highest_beaten(self) -> Optional[str]:
+        """The strongest opponent the challenger is shown to beat, or None if it beats none."""
+        beaten = [rung.spec for rung in self.rungs if rung.beaten]
+        return beaten[-1] if beaten else None
+
+    @property
+    def skipped(self) -> List[str]:
+        """
+        Rungs *below* the highest one beaten that were not themselves beaten.
+
+        Reported rather than smoothed over. A player that beats depth 5 while only drawing depth 4
+        has not simply "reached depth 5" - Connect 4 has real odd/even depth effects, and an
+        opponent that searches to an even ply can be genuinely harder for some players than one
+        that searches a ply deeper. Hiding that behind the highest number would be the sort of
+        summary that is tidier than the thing it summarises.
+        """
+        best = self.highest_beaten
+        if best is None:
+            return []
+        return [rung.spec for rung in self.rungs[:self._index(best)] if not rung.beaten]
+
+    def _index(self, spec: str) -> int:
+        return next(i for i, rung in enumerate(self.rungs) if rung.spec == spec)
+
+    def __str__(self) -> str:
+        lines = [
+            f'  {self.games} games per rung, from {self.games // 2} distinct '
+            f'{"level " if self.balanced else ""}openings {self.opening_plies} plies in',
+            f'  {"opponent":<22}{"score":>16}  {"record":<18} verdict',
+        ]
+        for rung in self.rungs:
+            result = rung.result
+            record = f'+{result.wins} ={result.draws} -{result.losses}'
+            lines.append(
+                f'  {rung.spec:<22}{result.score:>7.3f} +/- {result.error:.3f}  '
+                f'{record:<18} {rung.verdict}'
+            )
+
+        best = self.highest_beaten
+        lines.append('')
+        lines.append(f'  Highest rung beaten: {best if best else "none"}')
+        if self.skipped:
+            lines.append(f'  But did not beat: {", ".join(self.skipped)} — not a clean ladder')
+        return '\n'.join(lines)
+
+
+def balanced_openings(game: Type[GameState], states: Sequence[GameState]) -> List[GameState]:
+    """
+    Those openings that are drawn with perfect play, where the game can say which are.
+
+    Most openings are not drawn, and that matters more than it sounds. At four plies, 920 of Connect
+    4's 1,120 positions are already won for one side, and a pair played from a decided opening is
+    forced to 0.5 whenever *both* players convert it - so as players get stronger, those pairs stop
+    carrying any information at all and merely drag every score toward level.
+
+    Starting level instead is worth a lot, and it was measured rather than assumed. Over the same
+    fifty pairs:
+
+        minimax:2 vs minimax:6    all openings 0.425 +/- 0.045 (noise)
+                                drawn only    0.390 +/- 0.042 (significant)
+        minimax:4 vs minimax:6    all openings 0.390 +/- 0.044
+                                drawn only    0.315 +/- 0.041
+
+    A comparison that could not be told from noise becomes one that can. Depth 2 against depth 4
+    stays level either way, which is not the harness failing - the position benchmark says the same
+    thing, and Connect 4 has real odd/even depth effects.
+
+    Two sources of truth, and neither is new. A game small enough to solve gets solved outright; a
+    game with a corpus of exactly-solved positions gets looked up in it, which is how Connect 4
+    knows the value of a position four plies in that its own solver could not reach. A game with
+    neither keeps all its openings, because an unbalanced ladder still ranks players - it just
+    needs more games to do it.
+    """
+    from ai import corpus  # Local: corpus imports nothing from here, and this keeps it that way
+
+    if game.SOLVED_DEPTH is not None:
+        return [state for state in states if solve(state) == 0]
+
+    path = corpus.CORPORA.get(game.__name__)
+    if path is None:
+        log.warning(f'  {game.__name__} cannot say which openings are level; using all of them')
+        return list(states)
+
+    values = corpus.values(corpus.load(path))
+    drawn = []
+    for state in states:
+        try:
+            worths = values(state)
+        except KeyError:  # Deeper than the corpus enumerates; nothing to filter on
+            return list(states)
+        if max(worths.values()) == 0:
+            drawn.append(state)
+    return drawn
+
+
+def climb(
+    game: Type[GameState],
+    challenger: Callable,
+    ladder: Optional[Ladder] = None,
+    games: int = GAMES,
+    seed: int = 0,
+    print_progress: bool = True,
+) -> Standing:
+    """
+    Plays `challenger` against every rung and reports where it sits.
+
+    The same openings are used for every rung, which is deliberate: it is a paired comparison down
+    the whole ladder, so a rung looking harder than the one below it cannot be an artefact of the
+    positions it happened to be given.
+    """
+    ladder = ladder or for_game(game)
+    openings = openings_at(game, ladder.opening_plies)
+    if ladder.balanced:
+        openings = balanced_openings(game, openings)
+
+    pairs = games // 2
+    if len(openings) < pairs:
+        raise ValueError(
+            f'{game.__name__} has {len(openings)} usable openings {ladder.opening_plies} plies in'
+            f'{" that are drawn" if ladder.balanced else ""}, and {games} games needs {pairs}. '
+            f'Start the games deeper, or play fewer: repeating an opening between deterministic '
+            f'players replays the game rather than playing a new one.'
+        )
+
+    # Shuffled so that a smaller `games` is a spread across the openings rather than the first
+    # handful, which enumeration produces in a systematic order.
+    chosen = list(openings)
+    random.Random(seed).shuffle(chosen)
+    chosen = chosen[:pairs]
+
+    rungs = []
+    for spec in ladder.rungs:
+        if print_progress:
+            log.info(f'  vs {describe(spec)}...')
+        result = play_match(
+            game, challenger, player(spec),
+            games=games, seed=seed, print_summary=False, openings=chosen,
+        )
+        rungs.append(Rung(spec, result))
+
+    return Standing(rungs, games, ladder.opening_plies, ladder.balanced)
+
+
+def for_game(game: Type[GameState]) -> Ladder:
+    """The default ladder for a game, or a complaint naming the games that have one."""
+    try:
+        return LADDERS[game.__name__]
+    except KeyError:
+        raise SystemExit(
+            f'no ladder is defined for {game.__name__}. Games with one: '
+            f'{", ".join(sorted(LADDERS))}'
+        ) from None
+
+
+def make(rungs: Sequence[str], opening_plies: int, balanced: bool = True) -> Ladder:
+    """A ladder from specs given on a command line, for overriding the default sequence."""
+    return Ladder(tuple(rungs), opening_plies, balanced)

--- a/ai/match.py
+++ b/ai/match.py
@@ -28,7 +28,7 @@ not, and the difference between a real improvement and noise at fifty games is n
 """
 
 import random
-from typing import Callable, NamedTuple, Type
+from typing import Callable, NamedTuple, Optional, Sequence, Type
 
 import log
 from games.base import GameState
@@ -124,18 +124,40 @@ def play_match(
     opening_plies: int = OPENING_PLIES,
     seed: int = 0,
     print_summary: bool = True,
+    openings: Optional[Sequence[GameState]] = None,
 ) -> MatchResult:
     """
     Plays `challenger` against `incumbent` and returns the tally from the challenger's side.
 
     Games are played in pairs from a shared opening, the challenger moving first in one and
     second in the other, so an odd `games` is rounded down to the pair below it.
+
+    `openings` supplies the positions to start from instead of drawing them at random, one per
+    pair, and is what `ai.ladder` passes. The reason it exists is that the default draws *with
+    replacement*, and between two deterministic players a repeated opening is not a second game -
+    it is the first one played again, move for move. Measured at the default two opening plies,
+    fifty pairs of Connect 4 draw only about thirty distinct openings, so nearly half the games
+    carry no information while `MatchResult.error` still divides by all of them.
+
+    Drawing without replacement is therefore better, and it is not the default only because it
+    would silently move numbers already measured and written down - the evaluation results in the
+    README were produced by the random path. `ai.oracle.openings_at` produces distinct positions
+    for a caller that wants them.
     """
     rng = random.Random(seed)
     wins = draws = losses = 0
 
-    for pair in range(games // 2):
-        opening = _opening(new_game, rng, opening_plies)
+    pairs = games // 2
+    if openings is not None:
+        if len(openings) < pairs:
+            raise ValueError(
+                f'{games} games needs {pairs} openings and only {len(openings)} were given; '
+                f'repeating them would replay games rather than play new ones'
+            )
+        openings = list(openings)[:pairs]
+
+    for pair in range(pairs):
+        opening = openings[pair] if openings is not None else _opening(new_game, rng, opening_plies)
 
         for challenger_is_first in (True, False):
             state = opening.copy()

--- a/ai/oracle.py
+++ b/ai/oracle.py
@@ -198,6 +198,52 @@ def optimal_moves(state: GameState, _table: Optional[Table] = None) -> List[Any]
     return [move for move, value in values.items() if value == best]
 
 
+def openings_at(game: Callable[[], GameState], ply: int) -> List[GameState]:
+    """
+    Every distinct position `ply` moves into the game that is still running, as independent states.
+
+    `enumerate_positions` walks the whole tree and so only suits a game small enough to have one.
+    This stops at a fixed depth, which makes it affordable for any game: Connect 4 has 4.5e12
+    positions in total and 1,120 at ply four.
+
+    Written against the contract alone - `legal_moves`, `make_move`, `unmake_move`, `copy`,
+    `solver_key`, `is_game_over` - so it works for any game, chess included, without knowing what a
+    move is.
+
+    Deduplicated by `solver_key`, which is the point of it. Two uses want *distinct* positions
+    rather than a random sample that may repeat: `ai.generate` builds the corpus's enumerated tier
+    from these, and `ai.ladder` uses them as match openings, where a repeat is worse than useless -
+    two deterministic players replaying an opening play the identical game, which adds a result to
+    the tally without adding any information to it.
+
+    Breadth-first, level by level, keeping copies. Depth-first with a visited set would work too
+    and would hold one state at a time, but it would also revisit positions reachable at several
+    depths; a level at a time is both simpler and how the counts above are naturally stated.
+
+    Finished games are dropped as they appear. A position with nothing left to play is not an
+    opening, and neither is one somebody has already won.
+    """
+    if ply < 0:
+        raise ValueError(f'a position cannot be {ply} moves into a game')
+
+    frontier: Dict[Any, GameState] = {}
+    start = game()
+    if not start.is_game_over:
+        frontier[start.solver_key] = start
+
+    for _ in range(ply):
+        deeper: Dict[Any, GameState] = {}
+        for state in frontier.values():
+            for move in list(state.legal_moves):
+                state.make_move(move)
+                if not state.is_game_over and state.solver_key not in deeper:
+                    deeper[state.solver_key] = state.copy()
+                state.unmake_move()
+        frontier = deeper
+
+    return list(frontier.values())
+
+
 def enumerate_positions(game: Callable[[], GameState]) -> Iterator[Tuple[GameState, int]]:
     """
     Every position reachable from a new game, each yielded once, with the ply it occurs at.

--- a/tests/connect4/test_ladder.py
+++ b/tests/connect4/test_ladder.py
@@ -1,0 +1,327 @@
+"""
+The match ladder, and the one arithmetic invariant that pins it down.
+
+A ladder has no oracle - that is why it exists, for the game where the exact answer cannot be had
+in bulk - so it cannot be checked by comparing it with a right answer. What it can be checked
+against is an *identity* and a calibration.
+
+**The identity: a deterministic player against itself must score exactly 0.5.** Not approximately,
+and not on average. Both games of a pair start from the same opening and both are played by the
+same function, so they run identically move for move; whoever moves first wins both, or neither
+does. Every pair is therefore one win and one loss to the challenger, or two draws. Any other
+number means the pairing is broken, or the colours are assigned wrongly, or something is leaking
+between games - and none of those would be obvious from a plausible-looking score.
+
+**The calibration**: random must lose to a real search, and a deeper search must beat a shallower
+one. Numbers that fail those are measuring the harness rather than the players.
+
+The ladders used here are cut down - three cheap rungs and twenty games - because the suite should
+not spend a minute playing depth-6 Connect 4 to learn something twenty games at depth 2 already
+say. The default ladder's own shape is asserted separately, without playing anything.
+"""
+
+import random
+import unittest
+
+from ai.ladder import (
+    GAMES,
+    LADDERS,
+    Ladder,
+    Rung,
+    Standing,
+    balanced_openings,
+    climb,
+    for_game,
+    make,
+)
+from ai.match import MatchResult, play_match
+from ai.oracle import openings_at
+from ai.players import player
+from games.connect4.board import Connect4
+from games.tictactoe.board import TicTacToe
+
+# Cheap enough to run in the suite, and still enough rungs to be a ladder rather than a match.
+CHEAP = Ladder(rungs=('random', 'minimax:1', 'minimax:2'), opening_plies=4, balanced=False)
+FEW = 20
+
+
+def beaten(score: float = 0.9) -> MatchResult:
+    """A lopsided result, so that it is significant as well as ahead."""
+    wins = int(100 * score)
+    return MatchResult(wins=wins, draws=0, losses=100 - wins)
+
+
+def level() -> MatchResult:
+    return MatchResult(wins=50, draws=0, losses=50)
+
+
+class TestADeterministicPlayerAgainstItself(unittest.TestCase):
+    """
+    The identity the whole harness rests on, stated for both games.
+
+    Exactly 0.5, with no tolerance, because there is no randomness left in it once the openings are
+    fixed: this is arithmetic, not a measurement.
+    """
+
+    def test_it_scores_exactly_level_on_connect_four(self):
+        me = player('minimax:2')
+        result = play_match(
+            Connect4, me, me, games=FEW, print_summary=False,
+            openings=openings_at(Connect4, 4)[:FEW // 2],
+        )
+        self.assertEqual(0.5, result.score, str(result))
+        self.assertEqual(result.wins, result.losses)
+
+    def test_it_scores_exactly_level_on_tic_tac_toe(self):
+        me = player('minimax:9')
+        result = play_match(
+            TicTacToe, me, me, games=FEW, print_summary=False,
+            openings=openings_at(TicTacToe, 2)[:FEW // 2],
+        )
+        self.assertEqual(0.5, result.score, str(result))
+
+    def test_every_rung_of_a_self_ladder_that_is_the_same_player_is_level(self):
+        """The same statement through `climb`, which is where the openings are actually chosen."""
+        me = player('minimax:2')
+        standing = climb(Connect4, me, Ladder(('minimax:2',), 4, balanced=False),
+                         games=FEW, print_progress=False)
+        self.assertEqual(0.5, standing.rungs[0].result.score)
+        self.assertIsNone(standing.highest_beaten)
+
+
+class TestOpeningsAreNeverReused(unittest.TestCase):
+    """
+    The reason `play_match` grew an `openings` argument at all.
+
+    Two deterministic players replaying an opening play the identical game, so a repeat adds a
+    result to the tally without adding anything to what the tally knows. The default path draws
+    with replacement and does repeat; the ladder must not.
+    """
+
+    def test_a_match_starts_each_pair_from_a_different_position(self):
+        plies = 4
+        openings = openings_at(Connect4, plies)[:FEW // 2]
+        seen = []
+
+        def recorder(state):
+            if len(state.columns_played) == plies:
+                seen.append(state.signature)
+            return player('minimax:1')(state)
+
+        play_match(Connect4, recorder, player('minimax:2'), games=FEW,
+                   print_summary=False, openings=openings)
+
+        self.assertEqual(len(seen), len(set(seen)), 'an opening was played twice')
+        self.assertTrue(set(seen).issubset({state.signature for state in openings}))
+
+    def test_a_match_refuses_to_repeat_when_given_too_few(self):
+        with self.assertRaises(ValueError):
+            play_match(Connect4, player('random'), player('random'), games=FEW,
+                       print_summary=False, openings=openings_at(Connect4, 1))
+
+    def test_a_climb_refuses_when_the_game_has_too_few_openings(self):
+        """
+        Two plies of Connect 4 offer 49 positions, so 200 games cannot be honoured. Better to say
+        so than to quietly play 49 openings four times each and report 200 games.
+        """
+        with self.assertRaises(ValueError):
+            climb(Connect4, player('random'), Ladder(('random',), 2, balanced=False),
+                  games=200, print_progress=False)
+
+    def test_the_default_ladders_can_honour_the_default_game_count(self):
+        """
+        Counted the way the ladder counts it, which is after balancing. Tic-tac-toe starts three
+        plies in rather than two for exactly this reason: two plies leave 72 openings but only 24
+        drawn ones, and a 100-game ladder needs 50.
+        """
+        for name, ladder in LADDERS.items():
+            game = {'Connect4': Connect4, 'TicTacToe': TicTacToe}[name]
+            available = openings_at(game, ladder.opening_plies)
+            if ladder.balanced:
+                available = balanced_openings(game, available)
+            self.assertGreaterEqual(
+                len(available), GAMES // 2,
+                f'{name} starts {ladder.opening_plies} plies in, where only {len(available)} '
+                f'usable openings exist, but the default is {GAMES} games',
+            )
+
+
+class TestBalancedOpenings(unittest.TestCase):
+    """
+    Starting level, which is the difference between a ladder that discriminates and one that does
+    not. A pair played from a decided opening is forced to 0.5 as soon as both players convert it,
+    so those pairs go quiet exactly when the players get good enough to be worth telling apart.
+    """
+
+    def test_a_solvable_game_keeps_only_its_drawn_openings(self):
+        from ai.oracle import solve
+        drawn = balanced_openings(TicTacToe, openings_at(TicTacToe, 3))
+        self.assertTrue(drawn)
+        for state in drawn:
+            self.assertEqual(0, solve(state), str(state))
+
+    def test_it_keeps_the_drawn_ones_and_no_others(self):
+        from ai.oracle import solve
+        every = openings_at(TicTacToe, 3)
+        self.assertEqual(
+            sum(1 for state in every if solve(state) == 0),
+            len(balanced_openings(TicTacToe, every)),
+        )
+
+    def test_a_game_with_a_corpus_uses_it(self):
+        """
+        Connect 4 four plies in is far beyond what our own solver reaches, so this can only work by
+        looking the positions up in `ai/corpora/connect4.txt` - which is exactly why the corpus
+        enumerates the opening in full.
+        """
+        drawn = balanced_openings(Connect4, openings_at(Connect4, 4))
+        self.assertEqual(200, len(drawn), 'the corpus says 200 of the 1,120 are drawn')
+
+    def test_a_game_with_neither_keeps_every_opening(self):
+        """Chess can be neither solved nor looked up, and must still get a usable ladder."""
+        from games.chess.board import ChessBoard
+        every = openings_at(ChessBoard, 1)
+        with self.assertLogs('chess', level='WARNING'):  # log.py's logger does not propagate
+            self.assertEqual(len(every), len(balanced_openings(ChessBoard, every)))
+
+    def test_a_balanced_climb_still_scores_a_player_against_itself_level(self):
+        me = player('minimax:2')
+        standing = climb(TicTacToe, me, Ladder(('minimax:2',), 3), games=FEW,
+                         print_progress=False)
+        self.assertEqual(0.5, standing.rungs[0].result.score)
+
+
+class TestCalibration(unittest.TestCase):
+    """Players whose relative strength is not in doubt, so a surprise here is the harness."""
+
+    def test_random_loses_to_a_real_search(self):
+        """
+        Only the rungs that are searches are asserted. The bottom rung is random against random,
+        which is level in expectation and genuinely noisy over twenty games - asserting that a
+        random player beats nothing would be asserting that a coin never comes up heads twice.
+        """
+        random.seed(0)
+        standing = climb(Connect4, player('random'), CHEAP, games=FEW, print_progress=False)
+        by_spec = {rung.spec: rung for rung in standing.rungs}
+
+        self.assertTrue(by_spec['minimax:1'].lost, str(standing))
+        self.assertTrue(by_spec['minimax:2'].lost, str(standing))
+
+    def test_a_search_beats_random_and_a_shallower_search(self):
+        standing = climb(Connect4, player('minimax:4'), CHEAP, games=FEW, print_progress=False)
+        by_spec = {rung.spec: rung for rung in standing.rungs}
+
+        self.assertTrue(by_spec['random'].beaten, str(standing))
+        self.assertTrue(by_spec['minimax:1'].beaten, str(standing))
+
+    def test_every_rung_is_played_even_after_a_hopeless_loss(self):
+        """Fixed cost and comparable runs; the ladder does not stop where the player falls off."""
+        standing = climb(Connect4, player('random'), CHEAP, games=FEW, print_progress=False)
+        self.assertEqual(len(CHEAP.rungs), len(standing.rungs))
+        self.assertEqual(list(CHEAP.rungs), [rung.spec for rung in standing.rungs])
+
+    def test_every_game_is_accounted_for_on_every_rung(self):
+        standing = climb(Connect4, player('minimax:1'), CHEAP, games=FEW, print_progress=False)
+        for rung in standing.rungs:
+            self.assertEqual(FEW, rung.result.games, rung.spec)
+
+
+class TestReproducibility(unittest.TestCase):
+    """A number that moves between runs is a number you cannot quote."""
+
+    def test_the_same_seed_gives_the_same_standing(self):
+        scores = [
+            [rung.result.score for rung in
+             climb(Connect4, player('minimax:2'), CHEAP, games=FEW, seed=7,
+                   print_progress=False).rungs]
+            for _ in range(2)
+        ]
+        self.assertEqual(scores[0], scores[1])
+
+    def test_a_different_seed_chooses_different_openings(self):
+        def first_opening(seed):
+            standing_openings = openings_at(Connect4, CHEAP.opening_plies)
+            import random as _random
+            shuffled = list(standing_openings)
+            _random.Random(seed).shuffle(shuffled)
+            return shuffled[0].signature
+
+        self.assertNotEqual(first_opening(0), first_opening(1))
+
+
+class TestTheSummary(unittest.TestCase):
+    """
+    Read off synthetic results, so this needs no games and cannot be slow or flaky.
+
+    The interesting case is the non-monotonic one. Connect 4 has genuine odd/even depth effects, so
+    a player really can beat a deeper opponent while failing to beat a shallower one, and a summary
+    that reported only the highest number would make that invisible.
+    """
+
+    @staticmethod
+    def standing(*pairs) -> Standing:
+        return Standing([Rung(spec, result) for spec, result in pairs], 100, 4)
+
+    def test_the_highest_rung_beaten_is_the_last_one_beaten(self):
+        report = self.standing(
+            ('random', beaten()), ('minimax:1', beaten()), ('minimax:2', level()),
+        )
+        self.assertEqual('minimax:1', report.highest_beaten)
+        self.assertEqual([], report.skipped)
+
+    def test_beating_nothing_is_reported_as_nothing(self):
+        report = self.standing(('random', level()), ('minimax:1', beaten(0.1)))
+        self.assertIsNone(report.highest_beaten)
+        self.assertEqual([], report.skipped)
+        self.assertIn('none', str(report))
+
+    def test_a_rung_missed_below_the_highest_one_beaten_is_named(self):
+        report = self.standing(
+            ('random', beaten()), ('minimax:1', level()),
+            ('minimax:2', beaten()), ('minimax:3', level()),
+        )
+        self.assertEqual('minimax:2', report.highest_beaten)
+        self.assertEqual(['minimax:1'], report.skipped)
+        self.assertIn('not a clean ladder', str(report))
+
+    def test_being_ahead_is_not_the_same_as_beating(self):
+        """0.55 over 100 games is inside the noise, and must not count as a rung cleared."""
+        narrow = MatchResult(wins=55, draws=0, losses=45)
+        self.assertFalse(narrow.is_significant)
+        self.assertIsNone(self.standing(('random', narrow)).highest_beaten)
+
+    def test_the_verdicts_read_the_way_the_scores_do(self):
+        report = self.standing(
+            ('a', beaten()), ('b', level()), ('c', beaten(0.05)),
+        )
+        self.assertEqual(['beats', 'level', 'loses'], [rung.verdict for rung in report.rungs])
+
+
+class TestLadderConfiguration(unittest.TestCase):
+    def test_both_games_with_a_ladder_have_one(self):
+        self.assertEqual(for_game(Connect4), LADDERS['Connect4'])
+        self.assertEqual(for_game(TicTacToe), LADDERS['TicTacToe'])
+
+    def test_a_game_without_a_ladder_says_so(self):
+        from games.chess.board import ChessBoard
+        with self.assertRaises(SystemExit):
+            for_game(ChessBoard)
+
+    def test_the_rungs_get_harder(self):
+        """
+        Not an assertion about play, which would need games - only that the sequence is ordered as
+        written. A ladder whose rungs were shuffled would still run and would still report.
+        """
+        for ladder in LADDERS.values():
+            depths = [int(spec.split(':')[1]) for spec in ladder.rungs if spec.startswith('mini')]
+            self.assertEqual(sorted(depths), depths)
+            self.assertEqual('random', ladder.rungs[0], 'the bottom rung should be the weakest')
+
+    def test_a_ladder_can_be_overridden(self):
+        custom = make(['random', 'minimax:3'], opening_plies=2)
+        self.assertEqual(('random', 'minimax:3'), custom.rungs)
+        self.assertEqual(2, custom.opening_plies)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -49,6 +49,15 @@ from tests.connect4.test_evaluation import (
     TestThreatValue,
 )
 from tests.connect4.test_match import TestMatchResult, TestPlayMatch
+from tests.connect4.test_ladder import (
+    TestADeterministicPlayerAgainstItself,
+    TestBalancedOpenings,
+    TestOpeningsAreNeverReused,
+    TestCalibration,
+    TestReproducibility,
+    TestTheSummary,
+    TestLadderConfiguration,
+)
 from tests.connect4.test_solver import (
     TestPinnedCorpus,
     TestMirrorInvariance,
@@ -107,6 +116,7 @@ from tests.tictactoe.test_encoding import (
 from tests.test_oracle import (
     TestSolver,
     TestEnumeration,
+    TestOpeningsAtAPly,
     TestBenchmarkCalibration,
     TestPlayEveryLine,
     TestGrade,

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -19,6 +19,7 @@ from ai.oracle import (
     benchmark,
     enumerate_positions,
     move_values,
+    openings_at,
     optimal_moves,
     play_every_line,
     solve,
@@ -95,6 +96,65 @@ class TestEnumeration(unittest.TestCase):
     def test_plies_run_from_zero_to_a_full_board(self):
         plies = {ply for _, ply in enumerate_positions(TicTacToe)}
         self.assertEqual(set(range(CELLS + 1)), plies)
+
+
+class TestOpeningsAtAPly(unittest.TestCase):
+    """
+    Depth-limited enumeration, which `enumerate_positions` cannot stand in for: that one walks the
+    whole tree, and Connect 4's is 4.5e12 positions.
+
+    The counts below are properties of the games rather than of this code, which is what makes
+    them worth asserting. They are also load-bearing in two places - the corpus's enumerated tier
+    is built from them, and `ai.ladder` needs enough distinct positions to give every pair of a
+    match its own opening.
+    """
+
+    # Distinct still-running positions at each ply, derived independently by playing every move
+    # order out in a scratch script and deduplicating on the board.
+    TIC_TAC_TOE = [1, 9, 72, 252, 756, 1140, 1372]
+    CONNECT_FOUR = [1, 7, 49, 238, 1120, 4263, 16422]
+
+    def test_the_counts_are_what_the_games_say_they_are(self):
+        for ply, expected in enumerate(self.TIC_TAC_TOE):
+            self.assertEqual(expected, len(openings_at(TicTacToe, ply)), f'ply {ply}')
+
+    def test_it_works_for_a_game_far_too_big_to_enumerate_whole(self):
+        from games.connect4.board import Connect4
+        for ply, expected in enumerate(self.CONNECT_FOUR):
+            self.assertEqual(expected, len(openings_at(Connect4, ply)), f'ply {ply}')
+
+    def test_every_position_is_at_the_ply_asked_for(self):
+        for state in openings_at(TicTacToe, 4):
+            self.assertEqual(4, sum(bin(marks).count('1') for marks in state.marks.values()))
+
+    def test_no_position_is_repeated(self):
+        keys = [state.solver_key for state in openings_at(TicTacToe, 5)]
+        self.assertEqual(len(keys), len(set(keys)))
+
+    def test_finished_games_are_left_out(self):
+        """
+        An opening is somewhere a game can continue from. Tic-tac-toe can be won by ply 5, so this
+        is not hypothetical - and a finished position handed to a match would score without a move
+        being played.
+        """
+        for ply in range(len(self.TIC_TAC_TOE)):
+            for state in openings_at(TicTacToe, ply):
+                self.assertFalse(state.is_game_over, f'{state} at ply {ply}')
+
+    def test_the_states_are_independent_of_each_other(self):
+        """Copies, not one state rewound - a caller keeps them all at once and plays from each."""
+        first, second = openings_at(TicTacToe, 1)[:2]
+        before = second.signature
+        first.make_move(next(iter(first.legal_moves)))
+        self.assertEqual(before, second.signature)
+
+    def test_the_empty_board_is_the_only_opening_at_ply_zero(self):
+        self.assertEqual(1, len(openings_at(TicTacToe, 0)))
+        self.assertEqual(TicTacToe().signature, openings_at(TicTacToe, 0)[0].signature)
+
+    def test_a_negative_ply_is_refused(self):
+        with self.assertRaises(ValueError):
+            openings_at(TicTacToe, -1)
 
 
 class TestBenchmarkCalibration(unittest.TestCase):

--- a/zero.py
+++ b/zero.py
@@ -23,7 +23,7 @@ import sys
 from typing import Optional, Type
 
 import log
-from ai import corpus
+from ai import corpus, ladder
 from ai.match import play_match
 from ai.oracle import benchmark, enumerate_positions, optimal_moves, play_every_line
 from ai.players import describe, player, UnknownPlayer
@@ -170,6 +170,32 @@ def grade(args) -> None:
         )
 
 
+def climb_ladder(args) -> None:
+    """
+    Plays a player up a fixed sequence of opponents and says where it sits.
+
+    The other half of the pair `benchmark` starts. That one asks whether a player knows the game,
+    position by position against the exact answer; this asks whether it can be beaten, which is a
+    different question and often a differently-answered one.
+    """
+    game = _game(args.game)
+    chooser = _player(args.player)
+
+    rungs = ladder.for_game(game)
+    rungs = ladder.make(
+        args.rungs or rungs.rungs,
+        args.opening_plies or rungs.opening_plies,
+        balanced=not args.unbalanced,
+    )
+
+    log.info(f'Climbing the {game.__name__} ladder with {describe(args.player)}...')
+    random.seed(args.seed)  # For a challenger that samples; see grade()
+    standing = ladder.climb(game, chooser, rungs, games=args.games, seed=args.seed)
+
+    log.newline()
+    log.info(str(standing))
+
+
 def match(args) -> None:
     """Plays two players off against each other over many paired games."""
     game = _game(args.game)
@@ -212,6 +238,19 @@ def main(argv: Optional[list] = None) -> None:
     grader.add_argument('--seed', type=int, default=0,
                         help='seeds the global RNG, so a player that samples is reproducible')
     grader.set_defaults(run=grade)
+
+    climber = commands.add_parser('ladder', help='place a player against a fixed set of opponents')
+    climber.add_argument('--player', required=True, help='e.g. minimax:4, model:PATH+mcts:200')
+    climber.add_argument('--games', type=int, default=ladder.GAMES,
+                         help=f'games per rung (default {ladder.GAMES})')
+    climber.add_argument('--rungs', nargs='+', default=None,
+                         help='override the default sequence of opponents')
+    climber.add_argument('--opening-plies', type=int, default=None,
+                         help='how many random plies each game starts from')
+    climber.add_argument('--unbalanced', action='store_true',
+                         help='start from any opening, not only ones drawn with perfect play')
+    climber.add_argument('--seed', type=int, default=0)
+    climber.set_defaults(run=climb_ladder)
 
     matcher = commands.add_parser('match', help='play two players off against each other')
     matcher.add_argument('--a', required=True)


### PR DESCRIPTION
The other half of the pair PR #48 started. Grading against solved positions asks whether a player
**knows the game**; this asks whether it **can be beaten**. The two come apart sharply and in one
direction: the tic-tac-toe network is wrong in 77 positions and is still unbeatable, because a
player that does not blunder on the path it walks never arrives at the positions it would get wrong.

`play_every_line` answers that exhaustively and is exponential in the length of a game, so Connect 4
gets the affordable substitute — a fixed sequence of opponents, a fixed number of games against
each, one table.

```
$ python3 zero.py --game connect4 ladder --player minimax:4
```

| Challenger | `random` | `:1` | `:2` | `:3` | `:4` | `:5` | `:6` | Highest beaten |
|---|---|---|---|---|---|---|---|---|
| `random` | 0.460 | 0.050 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | **none** |
| `minimax:2` | 1.000 | 0.925 | 0.500 | 0.535 | 0.510 | 0.275 | 0.390 | **`minimax:1`** |
| `minimax:4` | 1.000 | 0.935 | 0.490 | 0.640 | 0.500 | 0.405 | 0.315 | **`minimax:3`** |

Seven rungs, 100 games each, about two minutes. **Every rung is played even after a bad loss**, so
two runs are always directly comparable — tracking a player over time is most of what this is for.

Most of the machinery already existed: `play_match` pairs its games with the sides swapped and
returns a score with a standard error. What needed doing was the openings, and two things about
them turned out to matter.

## They have to be distinct

Every player here is deterministic, so two games from one opening are the same game move for move.
`play_match` draws openings **with replacement** — measured, fifty pairs of Connect 4 get **30
distinct openings**, one of them four times:

| Opening plies | 2 | 3 | 4 | 6 |
|---|---|---|---|---|
| Distinct, out of 50 pairs | **30** | 42 | 50 | 50 |

So ~40% of a "100-game" match is replays carrying no information, while `MatchResult.error` still
divides by 100 and understates itself by about 1.3×. The ladder enumerates instead, through a new
`ai.oracle.openings_at`, and **raises rather than repeating**. `ai/generate.py` had a private copy
of that walk for the corpus and now shares this one.

The default random path is untouched on purpose: the evaluation numbers in the README (0.700 ±
0.019 and the rest) were measured under it and must not silently move.

## They also have to be level — this was not in the plan

Most openings are already won for somebody — **920 of Connect 4's 1,120 at four plies** — and a pair
from a decided opening is forced to 0.5 as soon as both players convert it. Those pairs go quiet
exactly when the players get good enough to be worth telling apart. Over the same fifty pairs:

| | all openings | drawn only |
|---|---|---|
| `minimax:2` vs `minimax:6` | 0.425 ± 0.045 *(noise)* | **0.390 ± 0.042 *(significant)*** |
| `minimax:4` vs `minimax:6` | 0.390 ± 0.044 | **0.315 ± 0.041** |

A comparison that could not be told from noise becomes one that can. I added this beyond what was
agreed, because shipping the weaker instrument once the measurement existed seemed the wrong call —
`--unbalanced` restores the old behaviour.

Connect 4 looks its openings up in the corpus, which is how it knows the value of a position four
plies in that its own solver cannot reach. Tic-tac-toe solves them outright, and starts three plies
in rather than two because two leave only 24 drawn openings against the 50 a full ladder needs. A
game with neither keeps all its openings and says so in a warning.

`minimax:2` against `minimax:4` stays level either way — those two really are close, and the
position benchmark says so independently.

## Two checks, neither needing an oracle

**A deterministic player against itself scores exactly 0.500.** Not approximately: both games of a
pair start from the same opening and are played by the same function, so they run identically and
the pair is one win and one loss. It appears on the diagonal of every table above, and any other
number means the pairing or the colour assignment is broken.

**A perfect player must never lose.** `minimax:9` on tic-tac-toe:

```
  opponent                         score  record             verdict
  random                  0.935 +/- 0.017  +87 =13 -0         beats
  minimax:1               0.810 +/- 0.024  +62 =38 -0         beats
  minimax:2               0.510 +/- 0.007  +2 =98 -0          level
  minimax:9               0.500 +/- 0.000  +0 =100 -0         level
```

**Zero losses on every rung.** Under the unbalanced ladder that same player "lost" 21 games to
`minimax:1` — not blunders, just lost openings it had been handed. The balancing change confirmed
by a second, independent route. It also never *beats* the strong rungs, because from a level
tic-tac-toe position nobody can.

## The summary says when a ladder is not clean

`minimax:4` beats depth 3 but not depth 2, so the report names both rather than quoting the higher
number. That is a real effect, not noise: Connect 4 has genuine odd/even depth effects, and the
position benchmark ranks depth 3 (99.54% optimal) above depth 4 (99.38%) independently.

## Verification

```bash
python3 -m unittest tests.test_all                          # 474 tests, ~78s, no install needed
python3 -m unittest tests.connect4.test_ladder              # the self-play identity and calibration
python3 zero.py --game connect4 ladder --player minimax:4
python3 zero.py ladder --player minimax:9                   # tic-tac-toe: must lose nothing
python3 zero.py benchmark --player minimax:9                # must still read 100%
```

474 tests pass, up from 439 — 27 for the ladder and 8 for `openings_at`, whose per-ply counts are
properties of the games rather than of the code. `tests/connect4/test_match.py` pins the existing
`play_match` behaviour this must not disturb, and does.

Two test faults worth naming, both caught by running rather than reading: `assertLogs` targeted the
root logger where `log.py`'s is named and does not propagate; and a first draft asserted that a
random player beats nothing, which is false — random against random over 20 games can drift
significantly, and asserting otherwise is asserting a coin never comes up heads twice.

## Limits

Depth 2 and depth 4 read level even balanced, because they are close. The ladder tops out at depth
6 — depth 7 costs six times more per game for one extra ply. And it is deliberately coarse: the
solved corpus is the precise instrument, this one only says roughly where a player sits.

## Not in here

**The Connect 4 network.** This was the last instrument it needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4qz6h7S61wio5RgkbGkEm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4qz6h7S61wio5RgkbGkEm)_