### PR TITLE
Free a pinned piece stacked sliders froze, and let en passant answer check

### DIFF
--- a/games/chess/board.py
+++ b/games/chess/board.py
@@ -313,6 +313,22 @@ class ChessBoard(GameState):
                 protectors |= _blocker
         return protectors
 
+    def _pinners(self, target: Square, colour: Colour, blocker: Bitboard) -> Bitboard:
+        """
+        Returns the pieces of the given colour pinning `blocker` against `target`: the sliders whose
+        path to the target holds the blocker and nothing else.
+
+        The exact match is what makes this correct when two sliders stack up on the same ray. Only
+        the nearer one pins; the one behind it is stopped by its own colleague wherever the blocker
+        goes, so it is attacking nothing. Counting it as a second pinner reads the position as a
+        double check and freezes a piece that is free to move along the ray.
+        """
+        pinners = BB_EMPTY
+        for attacker_sq in bitboard_to_squares(self._attackers(target, colour)):
+            if BB_BETWEEN[attacker_sq][target] & self.occupied == blocker:
+                pinners |= BB_SQUARES[attacker_sq]
+        return pinners
+
     def _pseudo_legal_moves(self, colour: Colour) -> Iterable[Move]:
         """Generates possible moves without taking into account check and the safety of the King."""
 
@@ -680,6 +696,21 @@ class ChessBoard(GameState):
         attacks = self._attack_bitboard(not self.turn, ignore=king)  # Pretend the King isn't there
         in_check = king & attacks
         for move in self._pseudo_legal_moves(self.turn):
+            # En passant clears two squares on one rank at once: the capturing pawn leaves, and the
+            # captured pawn is removed from beside it. Neither test below can see that. The pin test
+            # cannot, because self._protectors only recognises a pin held by exactly one blocker; the
+            # check test cannot, because it asks for a move onto the checking square or in front of
+            # it, and a pawn that has just double-pushed into check is answered by landing past it.
+            # Playing the capture out and looking at the result settles both, and costs nothing: a
+            # game offers an en passant capture in a handful of positions.
+            if self._is_en_passant(move):
+                self.make_move(move)
+                exposed = self.kings[not self.turn] & self._attack_bitboard(self.turn)
+                self.unmake_move()
+                if not exposed:
+                    yield move
+                continue
+
             # If we are moving the king we should be careful
             if move.from_square == king_pos:
                 if attacks & BB_SQUARES[move.to_square]:  # New position is under attack
@@ -691,13 +722,10 @@ class ChessBoard(GameState):
                     elif (attacks & BB_BETWEEN[move.from_square][move.to_square]) > BB_EMPTY:
                         continue  # Cannot castle if intermediate squares are under attack
 
-            # Cannot move this piece, it's protecting the King
+            # This piece is protecting the King, so it may only move along the pin ray
             if protectors & BB_SQUARES[move.from_square]:
-                all_attackers = self._attackers(king_pos, not self.turn)
-                protected_attacker = self._attackers(
-                    king_pos, not self.turn, filter_blockers=BB_SQUARES[move.from_square],
-                )
-                if not _is_safe(protected_attacker ^ all_attackers, king_pos, move):
+                pinners = self._pinners(king_pos, not self.turn, BB_SQUARES[move.from_square])
+                if not _is_safe(pinners, king_pos, move):
                     continue
 
             # If in check and we are not moving the king, we must protect it
@@ -706,17 +734,6 @@ class ChessBoard(GameState):
                     attackers = self._attackers(king_pos, not self.turn, filter_blockers=self.occupied)
                     if not _is_safe(attackers, king_pos, move):
                         continue
-
-            # En passant clears two squares on the same rank at once: the capturing pawn
-            # leaves, and the captured pawn is removed from beside it. The pin detection
-            # above cannot see this, because self._protectors only recognises a pin held by
-            # exactly one blocker. Play these captures out and look at the result instead.
-            if self._is_en_passant(move):
-                self.make_move(move)
-                exposed = self.kings[not self.turn] & self._attack_bitboard(self.turn)
-                self.unmake_move()
-                if exposed:
-                    continue
 
             yield move
 

--- a/tests/chess/test_moves.py
+++ b/tests/chess/test_moves.py
@@ -52,6 +52,41 @@ class TestMoves(unittest.TestCase):
             _moves = {m.uci for m in _board.legal_moves}
             self.assertEqual(_moves, match)
 
+    def test_pinned_piece_moves_along_the_pin_ray(self):
+        """
+        A pinned piece is not frozen: it may move anywhere along the ray it is pinned on, the
+        pinner's own square included. Only leaving the ray is illegal.
+        """
+        for fen, from_square, match in (
+            # Bishop e3 pinned to the King on f2 by the Bishop on c5
+            ('4k3/8/8/2b5/8/4B3/5K2/8 w - - 0 1', E3, {'e3d4', 'e3c5'}),
+
+            # Rook e8 pinned to the King on g8 by the Rook on b8
+            ('1r2R1K1/8/8/8/8/8/8/4k3 w - - 0 1', E8, {'e8b8', 'e8c8', 'e8d8', 'e8f8'}),
+        ):
+            _board = ChessBoard(fen=fen)
+            self.assertEqual({m.uci for m in _board.legal_moves if m.from_square == from_square}, match)
+
+    def test_a_slider_stacked_behind_the_pinner_pins_nothing(self):
+        """
+        Only the nearest enemy slider on a ray pins the piece in front of the King. One stacked
+        behind it is attacking nothing, because its colleague blocks the path wherever the pinned
+        piece goes, and counting it as a second pinner reads the position as a double check and
+        freezes the piece completely.
+
+        These are the positions above with a second slider added behind the pinner. The moves are
+        the same ones: the extra piece changes nothing.
+        """
+        for fen, from_square, match in (
+            # A Queen on b6 behind the pinning Bishop on c5
+            ('4k3/8/1q6/2b5/8/4B3/5K2/8 w - - 0 1', E3, {'e3d4', 'e3c5'}),
+
+            # A Rook on a8 behind the pinning Rook on b8
+            ('rr2R1K1/8/8/8/8/8/8/4k3 w - - 0 1', E8, {'e8b8', 'e8c8', 'e8d8', 'e8f8'}),
+        ):
+            _board = ChessBoard(fen=fen)
+            self.assertEqual({m.uci for m in _board.legal_moves if m.from_square == from_square}, match)
+
     def test_make_basic_moves(self):
         bb = ChessBoard()
         bb.make_move(Move.from_uci('c2c3'))
@@ -211,6 +246,25 @@ class TestMoves(unittest.TestCase):
 
         self.assertEqual(bb.en_passant_sq, G3)
         self.assertEqual({m.uci for m in bb.legal_moves if m.from_square == F4}, {'f4f3'})
+
+    def test_en_passant_answers_a_checking_pawn(self):
+        """
+        A pawn that double-pushes into check can be taken en passant, which answers the check by
+        removing the checker. The capture lands past the checking pawn rather than on it, so it
+        looks like neither a capture of the checker nor a block of the ray between it and the King.
+
+        Here it is the only legal reply, so refusing it scores the position as checkmate.
+        """
+        bb = ChessBoard('8/1B6/R7/5k2/5p1P/3N3P/6P1/1K6 w - - 0 1')
+        bb.make_move(Move.from_uci('g2g4'))  # Double-pushing to g4 checks the King on f5
+
+        self.assertEqual(bb.en_passant_sq, G3)
+        self.assertTrue(bb.is_in_check)
+        self.assertEqual({m.uci for m in bb.legal_moves}, {'f4g3'})
+        self.assertIsNone(bb.outcome)
+
+        bb.make_move(Move.from_uci('f4g3'))
+        self.assertEqual(bb.fen, '8/1B6/R7/5k2/7P/3N2pP/8/1K6 w - - 0 2')
 
     def test_promotion(self):
         b = ChessBoard('rnbqr3/pppp2P1/3k1n1p/2p1p3/3b4/8/PPPPPP1P/RNBQKBNR w KQ - 0 1')


### PR DESCRIPTION
Two positions where a legal move was refused.

A piece pinned against its King may still move along the pin ray, the pinner's
own square included. The pinner was found by taking every enemy slider aligned
with the King with blockers ignored, then subtracting those still attacking once
the moving piece was treated as the only blocker. With two sliders stacked on
the same ray the moving piece blocks both, so the difference named two pinners,
which reads as a double check, in which nothing but the King may move: every
move of the piece was refused. The slider behind is pinning nothing, because its
colleague in front blocks the path wherever the blocker goes. _pinners keeps
only sliders whose path to the King holds the moving piece and nothing else,
which is the test _protectors already applies from the other end.

En passant clears two squares on one rank at once, and the in-check test could
not see it either: the capture lands past the checking pawn rather than on it,
so it looked like neither a capture of the checker nor a block of the ray. A
pawn that double-pushes into check was untakeable, and in a position where the
capture is the only reply that scores as checkmate. The play-it-out check that
already existed for the pin case moves in front of both tests and answers alone,
which settles both. It costs nothing: a game offers an en passant capture in a
handful of positions.

Perft is unchanged against the published counts, checked a ply deeper than the
suite runs: starting position to 5, Kiwipete to 4, positions 3 to 5, 4 to 4, 5
to 4, and the pin-heavy position 6 to 4.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ESnTdTtfknWQd1GcNMzVqh